### PR TITLE
Implement Standalone Hashing Mode

### DIFF
--- a/.github/workflows/dexios-tests.yml
+++ b/.github/workflows/dexios-tests.yml
@@ -80,6 +80,26 @@ jobs:
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -esgHyk keyfile 100MB.bin 100MB.enc
     - name: Decrypt in stream mode (AES-256-GCM)
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -dsgHyk keyfile 100MB.enc 100MB.bin
+  hash-standalone-mode:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Retrieve Dexios
+      uses: actions/download-artifact@v3
+      with:
+        name: dexios
+        path: target/release/dexios
+    - name: Make Binary Executable
+      run: chmod +x /home/runner/work/dexios/dexios/target/release/dexios/dexios
+    - name: Generate test file
+      run: dd if=/dev/urandom of=100MB.bin bs=1M count=100
+    - name: Encrypt in stream mode (XChaCha20-Poly1305)
+      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -esxHyk keyfile 100MB.bin 100MB.enc
+    - name: Decrypt in stream mode (XChaCha20-Poly1305)
+      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -dsxHyk keyfile 100MB.enc 100MB.bin
+    - name: Standalone Hash Mode (with output hashes above to confirm it works)
+      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios hash 100MB.enc
   erase:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/dexios-tests.yml
+++ b/.github/workflows/dexios-tests.yml
@@ -94,6 +94,8 @@ jobs:
       run: chmod +x /home/runner/work/dexios/dexios/target/release/dexios/dexios
     - name: Generate test file
       run: dd if=/dev/urandom of=100MB.bin bs=1M count=100
+    - name: Generate keyfile
+      run: dd if=/dev/urandom of=keyfile bs=1 count=4096
     - name: Encrypt in stream mode (XChaCha20-Poly1305)
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -esxHyk keyfile 100MB.bin 100MB.enc
     - name: Decrypt in stream mode (XChaCha20-Poly1305)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -176,7 +176,7 @@ pub fn get_matches() -> clap::ArgMatches {
                         .short('m')
                         .long("memory")
                         .takes_value(false)
-                        .help("load the file into memory before encrypting"),
+                        .help("load the file into memory before decrypting"),
                 )
                 .arg(
                     Arg::new("password")
@@ -221,6 +221,32 @@ pub fn get_matches() -> clap::ArgMatches {
                         .help("specify the number of passes (default is 16)")
                         .min_values(0)
                         .default_missing_value("16"),
+                ),
+        )
+        .subcommand(
+            Command::new("hash")
+                .about("hash a file")
+                .arg(
+                    Arg::new("input")
+                        .value_name("input")
+                        .takes_value(true)
+                        .required(true)
+                        .help("the file to hash"),
+                )
+                .arg(
+                    Arg::new("memory")
+                        .short('m')
+                        .long("memory")
+                        .takes_value(false)
+                        .help("load the file into memory before hashing"),
+                )
+                .arg(
+                    Arg::new("stream")
+                        .short('s')
+                        .long("stream")
+                        .takes_value(false)
+                        .help("use stream hashing (default)")
+                        .conflicts_with("memory"),
                 ),
         )
         .get_matches()

--- a/src/decrypt/crypto.rs
+++ b/src/decrypt/crypto.rs
@@ -1,5 +1,3 @@
-use std::fs::File;
-use std::result::Result::Ok;
 use crate::global::{CipherType, DecryptStreamCiphers, BLOCK_SIZE, SALT_LEN};
 use aead::stream::DecryptorLE31;
 use aead::{Aead, NewAead};
@@ -11,8 +9,10 @@ use argon2::Argon2;
 use argon2::Params;
 use chacha20poly1305::{XChaCha20Poly1305, XNonce};
 use secrecy::{ExposeSecret, Secret};
+use std::fs::File;
 use std::io::Read;
 use std::io::Write;
+use std::result::Result::Ok;
 
 // this handles argon2id hashing with the provided key and salt
 fn get_key(raw_key: Secret<Vec<u8>>, salt: [u8; SALT_LEN]) -> Result<Secret<[u8; 32]>> {
@@ -53,8 +53,8 @@ pub fn decrypt_bytes_memory_mode(
                 Ok(cipher) => {
                     drop(key);
                     cipher
-                },
-                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key."))
+                }
+                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
             };
 
             match cipher.decrypt(nonce, data) {
@@ -68,8 +68,8 @@ pub fn decrypt_bytes_memory_mode(
                 Ok(cipher) => {
                     drop(key);
                     cipher
-                },
-                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key."))
+                }
+                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
             };
 
             match cipher.decrypt(nonce, data) {
@@ -112,10 +112,10 @@ pub fn decrypt_bytes_stream_mode(
                 Ok(cipher) => {
                     drop(key);
                     cipher
-                },
-                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key."))
+                }
+                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
             };
-            
+
             let mut nonce_bytes = [0u8; 8];
             input
                 .read(&mut nonce_bytes)
@@ -136,8 +136,8 @@ pub fn decrypt_bytes_stream_mode(
                 Ok(cipher) => {
                     drop(key);
                     cipher
-                },
-                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key."))
+                }
+                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
             };
 
             let mut nonce_bytes = [0u8; 20];

--- a/src/encrypt/crypto.rs
+++ b/src/encrypt/crypto.rs
@@ -1,19 +1,19 @@
-use std::fs::File;
-use std::result::Result::Ok;
 use crate::global::{CipherType, EncryptStreamCiphers, BLOCK_SIZE, SALT_LEN};
 use aead::stream::EncryptorLE31;
 use aead::{Aead, NewAead};
 use aes_gcm::{Aes256Gcm, Nonce};
 use anyhow::anyhow;
-use anyhow::Result;
 use anyhow::Context;
+use anyhow::Result;
 use argon2::Argon2;
 use argon2::Params;
 use chacha20poly1305::{XChaCha20Poly1305, XNonce};
 use rand::{prelude::StdRng, Rng, RngCore, SeedableRng};
 use secrecy::{ExposeSecret, Secret};
+use std::fs::File;
 use std::io::Read;
 use std::io::Write;
+use std::result::Result::Ok;
 
 // this generates a salt for password hashing
 fn gen_salt() -> [u8; SALT_LEN] {
@@ -63,8 +63,8 @@ pub fn encrypt_bytes_memory_mode(
                 Ok(cipher) => {
                     drop(key);
                     cipher
-                },
-                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key."))
+                }
+                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
             };
 
             let encrypted_bytes = match cipher.encrypt(nonce, data.expose_secret().as_slice()) {
@@ -85,15 +85,15 @@ pub fn encrypt_bytes_memory_mode(
                 Ok(cipher) => {
                     drop(key);
                     cipher
-                },
-                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key."))
+                }
+                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
             };
 
             let encrypted_bytes = match cipher.encrypt(nonce, data.expose_secret().as_slice()) {
                 Ok(bytes) => bytes,
                 Err(_) => return Err(anyhow!("Unable to encrypt the data")),
             };
-            
+
             drop(data);
 
             Ok((salt, nonce_bytes.to_vec(), encrypted_bytes))
@@ -125,8 +125,10 @@ pub fn encrypt_bytes_stream_mode(
                     Ok(cipher) => {
                         drop(key);
                         cipher
-                    },
-                    Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key."))
+                    }
+                    Err(_) => {
+                        return Err(anyhow!("Unable to create cipher with argon2id hashed key."))
+                    }
                 };
 
                 let stream = EncryptorLE31::from_aead(cipher, nonce);
@@ -144,8 +146,10 @@ pub fn encrypt_bytes_stream_mode(
                     Ok(cipher) => {
                         drop(key);
                         cipher
-                    },
-                    Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key."))
+                    }
+                    Err(_) => {
+                        return Err(anyhow!("Unable to create cipher with argon2id hashed key."))
+                    }
                 };
 
                 let stream = EncryptorLE31::from_aead(cipher, nonce_bytes.as_slice().into());

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -1,6 +1,9 @@
 use anyhow::{Ok, Result};
 
-use crate::global::SALT_LEN;
+use crate::global::{SALT_LEN, BLOCK_SIZE};
+
+use std::io::Read;
+use anyhow::Context;
 
 // this simply just hashes the provided salt, nonce and data
 // it returns a blake3 hash in hex format
@@ -11,4 +14,43 @@ pub fn hash_data_blake3(salt: &[u8; SALT_LEN], nonce: &[u8], data: &[u8]) -> Res
     hasher.update(data);
     let hash = hasher.finalize().to_hex().to_string();
     Ok(hash)
+}
+
+pub fn hash_stream(input: &str) -> Result<()> {
+    let mut input_file = std::fs::File::open(input).with_context(|| format!("Unable to open file: {}", input))?;
+    
+    println!("Hashing {} in stream mode (this may take a while)", input);
+    let mut hasher = blake3::Hasher::new();
+    
+    let mut buffer = [0u8; BLOCK_SIZE];
+
+    loop {
+        let read_count = input_file
+            .read(&mut buffer)
+            .with_context(|| format!("Unable to read data from file: {}", input))?;
+        hasher.update(&buffer);
+        if read_count != BLOCK_SIZE {
+            break;
+        }
+    }
+
+    let hash = hasher.finalize().to_hex().to_string();
+
+    println!("The hash for {} is: {}", input, hash);
+
+    Ok(())
+}
+
+pub fn hash_memory(input: &str) -> Result<()> {
+    let mut input_file = std::fs::File::open(input).with_context(|| format!("Unable to open file: {}", input))?;
+    let mut data = Vec::new();
+
+    input_file.read_to_end(&mut data).with_context(|| format!("Unable to read data from file: {}", input))?;
+
+    println!("Hashing {} in memory mode (this may take a while)", input);
+    let hash = blake3::hash(&data).to_hex().to_string();
+
+    println!("The hash for {} is: {}", input, hash);
+
+    Ok(())
 }

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -1,9 +1,9 @@
 use anyhow::{Ok, Result};
 
-use crate::global::{SALT_LEN, BLOCK_SIZE};
+use crate::global::{BLOCK_SIZE, SALT_LEN};
 
-use std::io::Read;
 use anyhow::Context;
+use std::io::Read;
 
 // this simply just hashes the provided salt, nonce and data
 // it returns a blake3 hash in hex format
@@ -17,11 +17,12 @@ pub fn hash_data_blake3(salt: &[u8; SALT_LEN], nonce: &[u8], data: &[u8]) -> Res
 }
 
 pub fn hash_stream(input: &str) -> Result<()> {
-    let mut input_file = std::fs::File::open(input).with_context(|| format!("Unable to open file: {}", input))?;
-    
+    let mut input_file =
+        std::fs::File::open(input).with_context(|| format!("Unable to open file: {}", input))?;
+
     println!("Hashing {} in stream mode (this may take a while)", input);
     let mut hasher = blake3::Hasher::new();
-    
+
     let mut buffer = [0u8; BLOCK_SIZE];
 
     loop {
@@ -42,10 +43,13 @@ pub fn hash_stream(input: &str) -> Result<()> {
 }
 
 pub fn hash_memory(input: &str) -> Result<()> {
-    let mut input_file = std::fs::File::open(input).with_context(|| format!("Unable to open file: {}", input))?;
+    let mut input_file =
+        std::fs::File::open(input).with_context(|| format!("Unable to open file: {}", input))?;
     let mut data = Vec::new();
 
-    input_file.read_to_end(&mut data).with_context(|| format!("Unable to read data from file: {}", input))?;
+    input_file
+        .read_to_end(&mut data)
+        .with_context(|| format!("Unable to read data from file: {}", input))?;
 
     println!("Hashing {} in memory mode (this may take a while)", input);
     let hash = blake3::hash(&data).to_hex().to_string();

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -28,7 +28,7 @@ pub fn hash_stream(input: &str) -> Result<()> {
         let read_count = input_file
             .read(&mut buffer)
             .with_context(|| format!("Unable to read data from file: {}", input))?;
-        hasher.update(&buffer);
+        hasher.update(&buffer[..read_count]);
         if read_count != BLOCK_SIZE {
             break;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use global::{CipherType, Parameters};
+use global::{CipherType, Parameters, BLOCK_SIZE};
 use std::result::Result::Ok;
 
 mod cli;
@@ -179,6 +179,23 @@ fn main() -> Result<()> {
                     .context("No input file/invalid text provided")?,
                 passes,
             )?;
+        },
+        Some(("hash", sub_matches)) => {
+            let file_name = sub_matches.value_of("input").context("No input file provided")?;
+            let file_size = std::fs::metadata(file_name).context("Unable to read metadata for x")?; // CHANGE THIS TO WITH CONTEXT
+
+            if sub_matches.is_present("memory") {
+                hashing::hash_memory(file_name)?;
+            } else {
+                if file_size.len() <= BLOCK_SIZE.try_into().context("Unable to parse stream block size as u64")?
+                {
+                    println!("Input file size is less than the stream block size - redirecting to memory mode");
+                    hashing::hash_memory(file_name)?;
+                } else {
+                    hashing::hash_stream(file_name)?;
+                }
+            }
+
         }
         _ => (),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,23 +179,26 @@ fn main() -> Result<()> {
                     .context("No input file/invalid text provided")?,
                 passes,
             )?;
-        },
+        }
         Some(("hash", sub_matches)) => {
-            let file_name = sub_matches.value_of("input").context("No input file provided")?;
-            let file_size = std::fs::metadata(file_name).context("Unable to read metadata for x")?; // CHANGE THIS TO WITH CONTEXT
+            let file_name = sub_matches
+                .value_of("input")
+                .context("No input file provided")?;
+            let file_size =
+                std::fs::metadata(file_name).context("Unable to read metadata for x")?; // CHANGE THIS TO WITH CONTEXT
 
             if sub_matches.is_present("memory") {
                 hashing::hash_memory(file_name)?;
+            } else if file_size.len()
+                <= BLOCK_SIZE
+                    .try_into()
+                    .context("Unable to parse stream block size as u64")?
+            {
+                println!("Input file size is less than the stream block size - redirecting to memory mode");
+                hashing::hash_memory(file_name)?;
             } else {
-                if file_size.len() <= BLOCK_SIZE.try_into().context("Unable to parse stream block size as u64")?
-                {
-                    println!("Input file size is less than the stream block size - redirecting to memory mode");
-                    hashing::hash_memory(file_name)?;
-                } else {
-                    hashing::hash_stream(file_name)?;
-                }
+                hashing::hash_stream(file_name)?;
             }
-
         }
         _ => (),
     }


### PR DESCRIPTION
This allows for the command `dexios hash test.txt`

It can use memory or stream mode, and implements the same checking that `encrypt.rs` and `decrypt.rs` implement to automatically detect whether or not the file should be hashed in memory or stream mode.

There are optional `-s` and `-m` switches, but `-s` will redirect you to memory mode if your file isn't large enough.