### PR TITLE
Header Functions

### DIFF
--- a/.github/workflows/dexios-tests.yml
+++ b/.github/workflows/dexios-tests.yml
@@ -80,6 +80,32 @@ jobs:
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -esgHyk keyfile 100MB.bin 100MB.enc
     - name: Decrypt in stream mode (AES-256-GCM)
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -dsgHyk keyfile 100MB.enc 100MB.bin
+  header-tests:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Retrieve Dexios
+      uses: actions/download-artifact@v3
+      with:
+        name: dexios
+        path: target/release/dexios
+    - name: Make Binary Executable
+      run: chmod +x /home/runner/work/dexios/dexios/target/release/dexios/dexios
+    - name: Generate test file
+      run: dd if=/dev/urandom of=100MB.bin bs=1M count=100
+    - name: Generate keyfile
+      run: dd if=/dev/urandom of=keyfile bs=1 count=4096
+    - name: Encrypt in stream mode (XChaCha20-Poly1305)
+      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -esxHyk keyfile 100MB.bin 100MB.enc
+    - name: Dump Header
+      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios header dump -sxy 100MB.enc 100MB.enc.header
+    - name: Strip Header
+      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios header strip -sxy 100MB.enc
+    - name: Restore Header
+      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios header restore -sxy 100MB.enc.header 100MB.enc
+    - name: Decrypt in stream mode (XChaCha20-Poly1305)
+      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -dsxHyk keyfile 100MB.enc 100MB.bin
   hash-standalone-mode:
     needs: build
     runs-on: ubuntu-latest

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -252,6 +252,7 @@ pub fn get_matches() -> clap::ArgMatches {
         .subcommand(
             Command::new("pack")
                 .about("pack a directory and then encrypt/decrypt it")
+                .subcommand_required(true)
                 .arg(
                     Arg::new("recursive")
                         .short('r')
@@ -294,6 +295,148 @@ pub fn get_matches() -> clap::ArgMatches {
                 )
                 .subcommand(encrypt.clone())
                 .subcommand(decrypt.clone()),
+        )
+        .subcommand(
+            Command::new("header")
+                .about("dexios header functions (advanced users only!)")
+                .subcommand_required(true)
+                .subcommand(
+                    Command::new("dump")
+                        .about("dump a header")
+                        .arg(
+                            Arg::new("input")
+                                .value_name("input")
+                                .takes_value(true)
+                                .required(true)
+                                .help("the file who's header you wish to dump"),
+                        )
+                        .arg(
+                            Arg::new("output")
+                                .value_name("output")
+                                .takes_value(true)
+                                .required(true)
+                                .help("the output file"),
+                        )
+                        .arg(
+                            Arg::new("gcm")
+                                .short('g')
+                                .long("gcm")
+                                .takes_value(false)
+                                .help("dump an AES-256-GCM header"),
+                        )
+                        .arg(
+                            Arg::new("xchacha")
+                                .short('x')
+                                .long("xchacha")
+                                .takes_value(false)
+                                .help("dump an XChaCha20-Poly1305 header")
+                                .conflicts_with("gcm"),
+                        )
+                        .arg(
+                            Arg::new("stream")
+                                .short('s')
+                                .long("stream")
+                                .takes_value(false)
+                                .help("restore a stream mode header"),
+                        )
+                        .arg(
+                            Arg::new("memory")
+                                .short('m')
+                                .long("memory")
+                                .takes_value(false)
+                                .help("restore a memory mode header")
+                                .conflicts_with("stream"),
+                        )
+                )
+                .subcommand(
+                    Command::new("restore")
+                        .about("restore a header")
+                        .arg(
+                            Arg::new("input")
+                                .value_name("input")
+                                .takes_value(true)
+                                .required(true)
+                                .help("the header file"),
+                        )
+                        .arg(
+                            Arg::new("output")
+                                .value_name("output")
+                                .takes_value(true)
+                                .required(true)
+                                .help("the file to apply the header to"),
+                        )
+                        .arg(
+                            Arg::new("gcm")
+                                .short('g')
+                                .long("gcm")
+                                .takes_value(false)
+                                .help("restore an AES-256-GCM header"),
+                        )
+                        .arg(
+                            Arg::new("xchacha")
+                                .short('x')
+                                .long("xchacha")
+                                .takes_value(false)
+                                .help("restore an XChaCha20-Poly1305 header")
+                                .conflicts_with("gcm"),
+                        )
+                        .arg(
+                            Arg::new("stream")
+                                .short('s')
+                                .long("stream")
+                                .takes_value(false)
+                                .help("restore a stream mode header"),
+                        )
+                        .arg(
+                            Arg::new("memory")
+                                .short('m')
+                                .long("memory")
+                                .takes_value(false)
+                                .help("restore a memory mode header")
+                                .conflicts_with("stream"),
+                        )
+                )
+                .subcommand(
+                    Command::new("strip")
+                        .about("strip a header")
+                        .arg(
+                            Arg::new("input")
+                                .value_name("input")
+                                .takes_value(true)
+                                .required(true)
+                                .help("the header file"),
+                        )
+                        .arg(
+                            Arg::new("gcm")
+                                .short('g')
+                                .long("gcm")
+                                .takes_value(false)
+                                .help("strip an AES-256-GCM header"),
+                        )
+                        .arg(
+                            Arg::new("xchacha")
+                                .short('x')
+                                .long("xchacha")
+                                .takes_value(false)
+                                .help("strip an XChaCha20-Poly1305 header")
+                                .conflicts_with("gcm"),
+                        )
+                        .arg(
+                            Arg::new("stream")
+                                .short('s')
+                                .long("stream")
+                                .takes_value(false)
+                                .help("strip a stream mode header"),
+                        )
+                        .arg(
+                            Arg::new("memory")
+                                .short('m')
+                                .long("memory")
+                                .takes_value(false)
+                                .help("strip a memory mode header")
+                                .conflicts_with("stream"),
+                        )
+                )
         )
         .get_matches()
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -303,6 +303,7 @@ pub fn get_matches() -> clap::ArgMatches {
                 .subcommand(
                     Command::new("dump")
                         .about("dump a header")
+                        .arg_required_else_help(true)
                         .arg(
                             Arg::new("input")
                                 .value_name("input")
@@ -358,6 +359,7 @@ pub fn get_matches() -> clap::ArgMatches {
                 .subcommand(
                     Command::new("restore")
                         .about("restore a header")
+                        .arg_required_else_help(true)
                         .arg(
                             Arg::new("input")
                                 .value_name("input")
@@ -413,6 +415,7 @@ pub fn get_matches() -> clap::ArgMatches {
                 .subcommand(
                     Command::new("strip")
                         .about("strip a header")
+                        .arg_required_else_help(true)
                         .arg(
                             Arg::new("input")
                                 .value_name("input")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -347,6 +347,13 @@ pub fn get_matches() -> clap::ArgMatches {
                                 .help("restore a memory mode header")
                                 .conflicts_with("stream"),
                         )
+                        .arg(
+                            Arg::new("skip")
+                                .short('y')
+                                .long("skip")
+                                .takes_value(false)
+                                .help("skip all prompts"),
+                        )
                 )
                 .subcommand(
                     Command::new("restore")
@@ -395,6 +402,13 @@ pub fn get_matches() -> clap::ArgMatches {
                                 .help("restore a memory mode header")
                                 .conflicts_with("stream"),
                         )
+                        .arg(
+                            Arg::new("skip")
+                                .short('y')
+                                .long("skip")
+                                .takes_value(false)
+                                .help("skip all prompts"),
+                        )
                 )
                 .subcommand(
                     Command::new("strip")
@@ -435,6 +449,13 @@ pub fn get_matches() -> clap::ArgMatches {
                                 .takes_value(false)
                                 .help("strip a memory mode header")
                                 .conflicts_with("stream"),
+                        )
+                        .arg(
+                            Arg::new("skip")
+                                .short('y')
+                                .long("skip")
+                                .takes_value(false)
+                                .help("skip all prompts"),
                         )
                 )
         )

--- a/src/global.rs
+++ b/src/global.rs
@@ -28,7 +28,8 @@ pub struct HeaderType {
 }
 
 #[derive(PartialEq, Eq)]
-pub enum DexiosMode { // could do with a better name
+pub enum DexiosMode {
+    // could do with a better name
     MemoryMode,
     StreamMode,
 }

--- a/src/global.rs
+++ b/src/global.rs
@@ -22,6 +22,17 @@ pub struct Parameters {
     pub cipher_type: CipherType,
 }
 
+pub struct HeaderType {
+    pub dexios_mode: DexiosMode,
+    pub cipher_type: CipherType,
+}
+
+#[derive(PartialEq, Eq)]
+pub enum DexiosMode { // could do with a better name
+    MemoryMode,
+    StreamMode,
+}
+
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum DirectoryMode {
     Singular,

--- a/src/global.rs
+++ b/src/global.rs
@@ -34,6 +34,15 @@ pub enum DexiosMode {
     StreamMode,
 }
 
+impl std::fmt::Display for DexiosMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            DexiosMode::MemoryMode => write!(f, "memory mode"),
+            DexiosMode::StreamMode => write!(f, "stream mode"),
+        }
+    }
+}
+
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum DirectoryMode {
     Singular,

--- a/src/header.rs
+++ b/src/header.rs
@@ -77,7 +77,7 @@ pub fn restore(input: &str, output: &str, skip: SkipMode, header_info: &HeaderTy
 
     let mut output_file = OpenOptions::new()
         .write(true)
-        .open(input)
+        .open(output)
         .with_context(|| format!("Unable to open output file: {}", output))?;
 
     output_file

--- a/src/header.rs
+++ b/src/header.rs
@@ -20,6 +20,7 @@ fn calc_nonce_len(header_info: &HeaderType) -> usize {
 }
 
 pub fn dump(input: &str, output: &str, skip: SkipMode, header_info: &HeaderType) -> Result<()> {
+    println!("THIS FEATURE IS FOR ADVANCED USERS ONLY AND MAY RESULT IN A LOSS OF DATA - PROCEED WITH CAUTION");
     let nonce_len = calc_nonce_len(header_info);
 
     let mut salt = [0u8; SALT_LEN];
@@ -59,6 +60,7 @@ pub fn dump(input: &str, output: &str, skip: SkipMode, header_info: &HeaderType)
 }
 
 pub fn restore(input: &str, output: &str, skip: SkipMode, header_info: &HeaderType) -> Result<()> {
+    println!("THIS FEATURE IS FOR ADVANCED USERS ONLY AND MAY RESULT IN A LOSS OF DATA - PROCEED WITH CAUTION");
     let prompt = format!("Are you sure you'd like to restore the header in {} to {}, and that it was created with {} in {}?", input, output, header_info.cipher_type, header_info.dexios_mode);
     if !get_answer(&prompt, false, skip == SkipMode::HidePrompts)? {
         exit(0);
@@ -87,6 +89,7 @@ pub fn restore(input: &str, output: &str, skip: SkipMode, header_info: &HeaderTy
 }
 
 pub fn strip(input: &str, skip: SkipMode, header_info: &HeaderType) -> Result<()> {
+    println!("THIS FEATURE IS FOR ADVANCED USERS ONLY AND MAY RESULT IN A LOSS OF DATA - PROCEED WITH CAUTION");
     let prompt = format!(
         "Are you sure you'd like to wipe the header for {}, and that it was created with {} in {}?",
         input, header_info.cipher_type, header_info.dexios_mode

--- a/src/header.rs
+++ b/src/header.rs
@@ -3,7 +3,7 @@ use crate::{
     prompt::{overwrite_check, get_answer},
 };
 use anyhow::{Context, Result};
-use std::{io::Read, process::exit};
+use std::{io::Read, process::exit, fs::OpenOptions};
 use std::{fs::File, io::Write};
 
 fn calc_nonce_len(header_info: &HeaderType) -> usize {
@@ -41,8 +41,7 @@ pub fn dump(input: &str, output: &str, skip: SkipMode, header_info: &HeaderType)
         ));
     }
 
-    if !overwrite_check(output, SkipMode::ShowPrompts, BenchMode::WriteToFilesystem)? {
-        // add -y support
+    if !overwrite_check(output, skip, BenchMode::WriteToFilesystem)? {
         std::process::exit(0);
     }
 
@@ -59,8 +58,30 @@ pub fn dump(input: &str, output: &str, skip: SkipMode, header_info: &HeaderType)
     Ok(())
 }
 
+pub fn restore(input: &str, output: &str, skip: SkipMode, header_info: &HeaderType) -> Result<()> {
+    let prompt = format!("Are you sure you'd like to restore the header in {} to {}, and that it was created with {} in {}?", input, output, header_info.cipher_type, header_info.dexios_mode);
+    if !get_answer(&prompt, false, skip == SkipMode::HidePrompts)? {
+        exit(0);
+    }
+
+    let nonce_len = calc_nonce_len(header_info);
+
+    let mut buffer = vec![0u8; SALT_LEN + nonce_len];
+    let mut input_file =
+        File::open(input).with_context(|| format!("Unable to open header file: {}", input))?;
+    input_file.read(&mut buffer).with_context(|| format!("Unable to read salt and nonce from file: {}", input))?;
+
+    let mut output_file =
+        OpenOptions::new().write(true).open(input).with_context(|| format!("Unable to open output file: {}", output))?;
+
+    output_file.write_all(&mut buffer).with_context(|| format!("Unable to write header to file: {}", output))?;
+
+    println!("Header restored to {} from {} successfully.", output, input);
+    Ok(())
+}
+
 pub fn strip(input: &str, skip: SkipMode, header_info: &HeaderType) -> Result<()> {
-    let prompt = format!("Are you sure you'd like to wipe the header for {}, and that {} in {} mode is correct?", input, header_info.cipher_type, header_info.dexios_mode);
+    let prompt = format!("Are you sure you'd like to wipe the header for {}, and that it was created with {} in {}?", input, header_info.cipher_type, header_info.dexios_mode);
     if !get_answer(&prompt, false, skip == SkipMode::HidePrompts)? {
         exit(0);
     }
@@ -70,7 +91,7 @@ pub fn strip(input: &str, skip: SkipMode, header_info: &HeaderType) -> Result<()
     let mut buffer = vec![0u8; SALT_LEN + nonce_len];
 
     let mut file =
-        File::open(input).with_context(|| format!("Unable to open input file: {}", input))?;
+        OpenOptions::new().write(true).open(input).with_context(|| format!("Unable to open input file: {}", input))?;
     
     file.write_all(&mut buffer).with_context(|| format!("Unable to wipe header for file: {}", input))?;
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use std::io::Read;
 use std::{fs::File, io::Write};
 
-pub fn dump(input: &str, output: &str, header_info: HeaderType) -> Result<()> {
+fn calc_nonce_len(header_info: &HeaderType) -> usize {
     let mut nonce_len = match header_info.cipher_type {
         CipherType::AesGcm => 12,
         CipherType::XChaCha20Poly1305 => 24,
@@ -15,6 +15,12 @@ pub fn dump(input: &str, output: &str, header_info: HeaderType) -> Result<()> {
     if header_info.dexios_mode == DexiosMode::StreamMode {
         nonce_len -= 4; // the last 4 bytes are dynamic in stream mode
     }
+
+    nonce_len
+}
+
+pub fn dump(input: &str, output: &str, header_info: &HeaderType) -> Result<()> {
+    let nonce_len = calc_nonce_len(header_info);
 
     let mut salt = [0u8; SALT_LEN];
     let mut nonce = vec![0u8; nonce_len];

--- a/src/header.rs
+++ b/src/header.rs
@@ -19,7 +19,7 @@ fn calc_nonce_len(header_info: &HeaderType) -> usize {
     nonce_len
 }
 
-pub fn dump(input: &str, output: &str, header_info: &HeaderType) -> Result<()> {
+pub fn dump(input: &str, output: &str, skip: SkipMode, header_info: &HeaderType) -> Result<()> {
     let nonce_len = calc_nonce_len(header_info);
 
     let mut salt = [0u8; SALT_LEN];

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,7 +1,10 @@
+use crate::{
+    global::{BenchMode, CipherType, DexiosMode, HeaderType, SkipMode, SALT_LEN},
+    prompt::overwrite_check,
+};
 use anyhow::{Context, Result};
-use std::{fs::File, io::Write};
 use std::io::Read;
-use crate::{global::{HeaderType, DexiosMode, CipherType, SALT_LEN, SkipMode, BenchMode}, prompt::overwrite_check};
+use std::{fs::File, io::Write};
 
 pub fn dump(input: &str, output: &str, header_info: HeaderType) -> Result<()> {
     let mut nonce_len = match header_info.cipher_type {
@@ -13,12 +16,11 @@ pub fn dump(input: &str, output: &str, header_info: HeaderType) -> Result<()> {
         nonce_len -= 4; // the last 4 bytes are dynamic in stream mode
     }
 
-
     let mut salt = [0u8; SALT_LEN];
     let mut nonce = vec![0u8; nonce_len];
 
-
-    let mut file = File::open(input).with_context(|| format!("Unable to open input file: {}", input))?;
+    let mut file =
+        File::open(input).with_context(|| format!("Unable to open input file: {}", input))?;
     let salt_size = file
         .read(&mut salt)
         .with_context(|| format!("Unable to read salt from file: {}", input))?;
@@ -32,14 +34,20 @@ pub fn dump(input: &str, output: &str, header_info: HeaderType) -> Result<()> {
             input
         ));
     }
-    
-    if !overwrite_check(output, SkipMode::ShowPrompts, BenchMode::WriteToFilesystem)? { // add -y support
+
+    if !overwrite_check(output, SkipMode::ShowPrompts, BenchMode::WriteToFilesystem)? {
+        // add -y support
         std::process::exit(0);
     }
 
-    let mut output_file = File::create(output).with_context(|| format!("Unable to open output file: {}", output))?;
-    output_file.write_all(&salt).with_context(|| format!("Unable to write salt to output file: {}", output))?;
-    output_file.write_all(&nonce).with_context(|| format!("Unable to write nonce to output file: {}", output))?;
+    let mut output_file =
+        File::create(output).with_context(|| format!("Unable to open output file: {}", output))?;
+    output_file
+        .write_all(&salt)
+        .with_context(|| format!("Unable to write salt to output file: {}", output))?;
+    output_file
+        .write_all(&nonce)
+        .with_context(|| format!("Unable to write nonce to output file: {}", output))?;
 
     println!("Header dumped to {} successfully.", output);
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,10 +1,10 @@
 use crate::{
     global::{BenchMode, CipherType, DexiosMode, HeaderType, SkipMode, SALT_LEN},
-    prompt::{overwrite_check, get_answer},
+    prompt::{get_answer, overwrite_check},
 };
 use anyhow::{Context, Result};
-use std::{io::Read, process::exit, fs::OpenOptions};
 use std::{fs::File, io::Write};
+use std::{fs::OpenOptions, io::Read, process::exit};
 
 fn calc_nonce_len(header_info: &HeaderType) -> usize {
     let mut nonce_len = match header_info.cipher_type {
@@ -69,31 +69,43 @@ pub fn restore(input: &str, output: &str, skip: SkipMode, header_info: &HeaderTy
     let mut buffer = vec![0u8; SALT_LEN + nonce_len];
     let mut input_file =
         File::open(input).with_context(|| format!("Unable to open header file: {}", input))?;
-    input_file.read(&mut buffer).with_context(|| format!("Unable to read salt and nonce from file: {}", input))?;
+    input_file
+        .read(&mut buffer)
+        .with_context(|| format!("Unable to read salt and nonce from file: {}", input))?;
 
-    let mut output_file =
-        OpenOptions::new().write(true).open(input).with_context(|| format!("Unable to open output file: {}", output))?;
+    let mut output_file = OpenOptions::new()
+        .write(true)
+        .open(input)
+        .with_context(|| format!("Unable to open output file: {}", output))?;
 
-    output_file.write_all(&mut buffer).with_context(|| format!("Unable to write header to file: {}", output))?;
+    output_file
+        .write_all(&mut buffer)
+        .with_context(|| format!("Unable to write header to file: {}", output))?;
 
     println!("Header restored to {} from {} successfully.", output, input);
     Ok(())
 }
 
 pub fn strip(input: &str, skip: SkipMode, header_info: &HeaderType) -> Result<()> {
-    let prompt = format!("Are you sure you'd like to wipe the header for {}, and that it was created with {} in {}?", input, header_info.cipher_type, header_info.dexios_mode);
+    let prompt = format!(
+        "Are you sure you'd like to wipe the header for {}, and that it was created with {} in {}?",
+        input, header_info.cipher_type, header_info.dexios_mode
+    );
     if !get_answer(&prompt, false, skip == SkipMode::HidePrompts)? {
         exit(0);
     }
 
     let nonce_len = calc_nonce_len(header_info);
-    
+
     let mut buffer = vec![0u8; SALT_LEN + nonce_len];
 
-    let mut file =
-        OpenOptions::new().write(true).open(input).with_context(|| format!("Unable to open input file: {}", input))?;
-    
-    file.write_all(&mut buffer).with_context(|| format!("Unable to wipe header for file: {}", input))?;
+    let mut file = OpenOptions::new()
+        .write(true)
+        .open(input)
+        .with_context(|| format!("Unable to open input file: {}", input))?;
+
+    file.write_all(&mut buffer)
+        .with_context(|| format!("Unable to wipe header for file: {}", input))?;
 
     println!("Header stripped from {} successfully.", input);
     Ok(())

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,0 +1,47 @@
+use anyhow::{Context, Result};
+use std::{fs::File, io::Write};
+use std::io::Read;
+use crate::{global::{HeaderType, DexiosMode, CipherType, SALT_LEN, SkipMode, BenchMode}, prompt::overwrite_check};
+
+pub fn dump(input: &str, output: &str, header_info: HeaderType) -> Result<()> {
+    let mut nonce_len = match header_info.cipher_type {
+        CipherType::AesGcm => 12,
+        CipherType::XChaCha20Poly1305 => 24,
+    };
+
+    if header_info.dexios_mode == DexiosMode::StreamMode {
+        nonce_len -= 4; // the last 4 bytes are dynamic in stream mode
+    }
+
+
+    let mut salt = [0u8; SALT_LEN];
+    let mut nonce: Vec<u8> = Vec::with_capacity(nonce_len);
+
+
+    let mut file = File::open(input).with_context(|| format!("Unable to open input file: {}", input))?;
+    let salt_size = file
+        .read(&mut salt)
+        .with_context(|| format!("Unable to read salt from file: {}", input))?;
+    let nonce_size = file
+        .read(&mut nonce)
+        .with_context(|| format!("Unable to read nonce from file: {}", input))?;
+    drop(file);
+    if salt_size != SALT_LEN || nonce_size != nonce_len {
+        return Err(anyhow::anyhow!(
+            "Input file ({}) does not contain the correct amount of information",
+            input
+        ));
+    }
+    
+    if !overwrite_check(output, SkipMode::ShowPrompts, BenchMode::WriteToFilesystem)? { // add -y support
+        std::process::exit(0);
+    }
+
+    let mut output_file = File::create(output).with_context(|| format!("Unable to open output file: {}", output))?;
+    output_file.write_all(&salt).with_context(|| format!("Unable to write salt to output file: {}", output))?;
+    output_file.write_all(&nonce).with_context(|| format!("Unable to write nonce to output file: {}", output))?;
+
+    println!("Header dumped to {} successfully.", output);
+
+    Ok(())
+}

--- a/src/header.rs
+++ b/src/header.rs
@@ -79,7 +79,7 @@ pub fn restore(input: &str, output: &str, skip: SkipMode, header_info: &HeaderTy
         .with_context(|| format!("Unable to open output file: {}", output))?;
 
     output_file
-        .write_all(&mut buffer)
+        .write_all(&buffer)
         .with_context(|| format!("Unable to write header to file: {}", output))?;
 
     println!("Header restored to {} from {} successfully.", output, input);
@@ -97,14 +97,14 @@ pub fn strip(input: &str, skip: SkipMode, header_info: &HeaderType) -> Result<()
 
     let nonce_len = calc_nonce_len(header_info);
 
-    let mut buffer = vec![0u8; SALT_LEN + nonce_len];
+    let buffer = vec![0u8; SALT_LEN + nonce_len];
 
     let mut file = OpenOptions::new()
         .write(true)
         .open(input)
         .with_context(|| format!("Unable to open input file: {}", input))?;
 
-    file.write_all(&mut buffer)
+    file.write_all(&buffer)
         .with_context(|| format!("Unable to wipe header for file: {}", input))?;
 
     println!("Header stripped from {} successfully.", input);

--- a/src/header.rs
+++ b/src/header.rs
@@ -15,7 +15,7 @@ pub fn dump(input: &str, output: &str, header_info: HeaderType) -> Result<()> {
 
 
     let mut salt = [0u8; SALT_LEN];
-    let mut nonce: Vec<u8> = Vec::with_capacity(nonce_len);
+    let mut nonce = vec![0u8; nonce_len];
 
 
     let mut file = File::open(input).with_context(|| format!("Unable to open input file: {}", input))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,7 +230,7 @@ fn main() -> Result<()> {
                     sub_matches_dump
                         .value_of("output")
                         .context("No output file/invalid text provided")?,
-                    header_type,
+                    &header_type,
                 )?;
             }
             Some("restore") => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use global::{DirectoryMode, HiddenFilesMode, PrintMode, BLOCK_SIZE, SkipMode};
+use global::{DirectoryMode, HiddenFilesMode, PrintMode, SkipMode, BLOCK_SIZE};
 use param_handler::{header_type_handler, param_handler};
 use std::result::Result::Ok;
 
@@ -235,7 +235,7 @@ fn main() -> Result<()> {
                     sub_matches_dump
                         .value_of("output")
                         .context("No output file/invalid text provided")?,
-                        skip,
+                    skip,
                     &header_type,
                 )?;
             }
@@ -252,10 +252,10 @@ fn main() -> Result<()> {
                     sub_matches_restore
                         .value_of("input")
                         .context("No input file/invalid text provided")?,
-                        sub_matches_restore
+                    sub_matches_restore
                         .value_of("output")
                         .context("No input file/invalid text provided")?,
-                        skip,
+                    skip,
                     &header_type,
                 )?;
             }
@@ -272,7 +272,7 @@ fn main() -> Result<()> {
                     sub_matches_strip
                         .value_of("input")
                         .context("No input file/invalid text provided")?,
-                        skip,
+                    skip,
                     &header_type,
                 )?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use global::{DirectoryMode, HiddenFilesMode, PrintMode, BLOCK_SIZE, HeaderType, DexiosMode, CipherType};
+use global::{DirectoryMode, HiddenFilesMode, PrintMode, BLOCK_SIZE};
 use param_handler::{param_handler, header_type_handler};
 use std::result::Result::Ok;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use global::{DirectoryMode, HiddenFilesMode, PrintMode, BLOCK_SIZE};
+use global::{DirectoryMode, HiddenFilesMode, PrintMode, BLOCK_SIZE, SkipMode};
 use param_handler::{header_type_handler, param_handler};
 use std::result::Result::Ok;
 
@@ -222,6 +222,11 @@ fn main() -> Result<()> {
             Some("dump") => {
                 let sub_matches_dump = sub_matches.subcommand_matches("dump").unwrap();
                 let header_type = header_type_handler(sub_matches_dump)?;
+                let skip = if sub_matches_dump.is_present("skip") {
+                    SkipMode::HidePrompts
+                } else {
+                    SkipMode::ShowPrompts
+                };
 
                 header::dump(
                     sub_matches_dump
@@ -230,11 +235,28 @@ fn main() -> Result<()> {
                     sub_matches_dump
                         .value_of("output")
                         .context("No output file/invalid text provided")?,
+                        skip,
                     &header_type,
                 )?;
             }
             Some("restore") => {}
-            Some("strip") => {}
+            Some("strip") => {
+                let sub_matches_strip = sub_matches.subcommand_matches("strip").unwrap();
+                let header_type = header_type_handler(sub_matches_strip)?;
+                let skip = if sub_matches_strip.is_present("skip") {
+                    SkipMode::HidePrompts
+                } else {
+                    SkipMode::ShowPrompts
+                };
+
+                header::strip(
+                    sub_matches_strip
+                        .value_of("input")
+                        .context("No input file/invalid text provided")?,
+                        skip,
+                    &header_type,
+                )?;
+            }
             _ => (),
         },
         _ => (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
-use global::{DirectoryMode, HiddenFilesMode, PrintMode, BLOCK_SIZE};
-use param_handler::param_handler;
+use global::{DirectoryMode, HiddenFilesMode, PrintMode, BLOCK_SIZE, HeaderType, DexiosMode, CipherType};
+use param_handler::{param_handler, header_type_handler};
 use std::result::Result::Ok;
 
 mod cli;
@@ -14,6 +14,7 @@ mod key;
 mod pack;
 mod param_handler;
 mod prompt;
+mod header;
 
 #[allow(clippy::too_many_lines)]
 fn main() -> Result<()> {
@@ -213,6 +214,24 @@ fn main() -> Result<()> {
                         &print_mode,
                         &params,
                     )?;
+                }
+                _ => (),
+            }
+        },
+        Some(("header", sub_matches)) => {
+            match sub_matches.subcommand_name() {
+                Some("dump") => {
+                    let sub_matches_dump = sub_matches.subcommand_matches("dump").unwrap();
+                    let header_type = header_type_handler(sub_matches_dump)?;
+
+                    header::dump(sub_matches_dump.value_of("input").context("No input file/invalid text provided")?, sub_matches_dump.value_of("output").context("No output file/invalid text provided")?, header_type)?;
+                  
+                }
+                Some("restore") => {
+                    
+                }
+                Some("strip") => {
+                    
                 }
                 _ => (),
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,7 +239,26 @@ fn main() -> Result<()> {
                     &header_type,
                 )?;
             }
-            Some("restore") => {}
+            Some("restore") => {
+                let sub_matches_restore = sub_matches.subcommand_matches("restore").unwrap();
+                let header_type = header_type_handler(sub_matches_restore)?;
+                let skip = if sub_matches_restore.is_present("skip") {
+                    SkipMode::HidePrompts
+                } else {
+                    SkipMode::ShowPrompts
+                };
+
+                header::restore(
+                    sub_matches_restore
+                        .value_of("input")
+                        .context("No input file/invalid text provided")?,
+                        sub_matches_restore
+                        .value_of("output")
+                        .context("No input file/invalid text provided")?,
+                        skip,
+                    &header_type,
+                )?;
+            }
             Some("strip") => {
                 let sub_matches_strip = sub_matches.subcommand_matches("strip").unwrap();
                 let header_type = header_type_handler(sub_matches_strip)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use global::{DirectoryMode, HiddenFilesMode, PrintMode, BLOCK_SIZE};
-use param_handler::{param_handler, header_type_handler};
+use param_handler::{header_type_handler, param_handler};
 use std::result::Result::Ok;
 
 mod cli;
@@ -10,11 +10,11 @@ mod erase;
 mod file;
 mod global;
 mod hashing;
+mod header;
 mod key;
 mod pack;
 mod param_handler;
 mod prompt;
-mod header;
 
 #[allow(clippy::too_many_lines)]
 fn main() -> Result<()> {
@@ -217,25 +217,26 @@ fn main() -> Result<()> {
                 }
                 _ => (),
             }
-        },
-        Some(("header", sub_matches)) => {
-            match sub_matches.subcommand_name() {
-                Some("dump") => {
-                    let sub_matches_dump = sub_matches.subcommand_matches("dump").unwrap();
-                    let header_type = header_type_handler(sub_matches_dump)?;
-
-                    header::dump(sub_matches_dump.value_of("input").context("No input file/invalid text provided")?, sub_matches_dump.value_of("output").context("No output file/invalid text provided")?, header_type)?;
-                  
-                }
-                Some("restore") => {
-                    
-                }
-                Some("strip") => {
-                    
-                }
-                _ => (),
-            }
         }
+        Some(("header", sub_matches)) => match sub_matches.subcommand_name() {
+            Some("dump") => {
+                let sub_matches_dump = sub_matches.subcommand_matches("dump").unwrap();
+                let header_type = header_type_handler(sub_matches_dump)?;
+
+                header::dump(
+                    sub_matches_dump
+                        .value_of("input")
+                        .context("No input file/invalid text provided")?,
+                    sub_matches_dump
+                        .value_of("output")
+                        .context("No output file/invalid text provided")?,
+                    header_type,
+                )?;
+            }
+            Some("restore") => {}
+            Some("strip") => {}
+            _ => (),
+        },
         _ => (),
     }
     Ok(())

--- a/src/param_handler.rs
+++ b/src/param_handler.rs
@@ -85,11 +85,15 @@ pub fn param_handler(sub_matches: &ArgMatches) -> Result<(&str, Parameters)> {
 
 pub fn header_type_handler(sub_matches: &ArgMatches) -> Result<HeaderType> {
     if !sub_matches.is_present("memory") && !sub_matches.is_present("stream") {
-        return Err(anyhow::anyhow!("You need to specify if the file was created in memory or stream mode."))
+        return Err(anyhow::anyhow!(
+            "You need to specify if the file was created in memory or stream mode."
+        ));
     }
 
     if !sub_matches.is_present("xchacha") && !sub_matches.is_present("gcm") {
-        return Err(anyhow::anyhow!("You need to specify if the file was created using XChaCha20-Poly1305 or AES-256-GCM."))
+        return Err(anyhow::anyhow!(
+            "You need to specify if the file was created using XChaCha20-Poly1305 or AES-256-GCM."
+        ));
     }
 
     let dexios_mode = if sub_matches.is_present("memory") {

--- a/src/param_handler.rs
+++ b/src/param_handler.rs
@@ -109,7 +109,7 @@ pub fn header_type_handler(sub_matches: &ArgMatches) -> Result<HeaderType> {
     };
 
     Ok(HeaderType {
-        cipher_type,
         dexios_mode,
+        cipher_type,
     })
 }

--- a/src/param_handler.rs
+++ b/src/param_handler.rs
@@ -84,6 +84,14 @@ pub fn param_handler(sub_matches: &ArgMatches) -> Result<(&str, Parameters)> {
 }
 
 pub fn header_type_handler(sub_matches: &ArgMatches) -> Result<HeaderType> {
+    if !sub_matches.is_present("memory") && !sub_matches.is_present("stream") {
+        return Err(anyhow::anyhow!("You need to specify if the file was created in memory or stream mode."))
+    }
+
+    if !sub_matches.is_present("xchacha") && !sub_matches.is_present("gcm") {
+        return Err(anyhow::anyhow!("You need to specify if the file was created using XChaCha20-Poly1305 or AES-256-GCM."))
+    }
+
     let dexios_mode = if sub_matches.is_present("memory") {
         DexiosMode::MemoryMode
     } else {

--- a/src/param_handler.rs
+++ b/src/param_handler.rs
@@ -1,5 +1,6 @@
 use crate::global::{
-    BenchMode, CipherType, EraseMode, HashMode, Parameters, PasswordMode, SkipMode, HeaderType, DexiosMode,
+    BenchMode, CipherType, DexiosMode, EraseMode, HashMode, HeaderType, Parameters, PasswordMode,
+    SkipMode,
 };
 use anyhow::{Context, Result};
 use clap::ArgMatches;
@@ -95,5 +96,8 @@ pub fn header_type_handler(sub_matches: &ArgMatches) -> Result<HeaderType> {
         CipherType::XChaCha20Poly1305
     };
 
-    Ok(HeaderType { cipher_type, dexios_mode })
+    Ok(HeaderType {
+        cipher_type,
+        dexios_mode,
+    })
 }

--- a/src/param_handler.rs
+++ b/src/param_handler.rs
@@ -1,5 +1,5 @@
 use crate::global::{
-    BenchMode, CipherType, EraseMode, HashMode, Parameters, PasswordMode, SkipMode,
+    BenchMode, CipherType, EraseMode, HashMode, Parameters, PasswordMode, SkipMode, HeaderType, DexiosMode,
 };
 use anyhow::{Context, Result};
 use clap::ArgMatches;
@@ -80,4 +80,20 @@ pub fn param_handler(sub_matches: &ArgMatches) -> Result<(&str, Parameters)> {
             cipher_type,
         },
     ))
+}
+
+pub fn header_type_handler(sub_matches: &ArgMatches) -> Result<HeaderType> {
+    let dexios_mode = if sub_matches.is_present("memory") {
+        DexiosMode::MemoryMode
+    } else {
+        DexiosMode::StreamMode
+    };
+
+    let cipher_type = if sub_matches.is_present("gcm") {
+        CipherType::AesGcm
+    } else {
+        CipherType::XChaCha20Poly1305
+    };
+
+    Ok(HeaderType { cipher_type, dexios_mode })
 }


### PR DESCRIPTION
This branch adds functions for manipulating headers created by Dexios.

It factors in the varying nonce sizes with input from the user, and is recommended for advanced users only.

These warnings are plastered around adequately.

This feature could be helpful for storing the header separate from the encrypted file (e.g. store the header on a USB drive and the file on your PC), meaning an attacker would have a **very** hard time brute-forcing the data.