### PR TITLE
Implement custom Secret type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,8 +275,8 @@ dependencies = [
  "chacha20poly1305",
  "clap",
  "rand",
- "secrecy",
  "termion",
+ "zeroize",
  "zip",
 ]
 
@@ -487,15 +487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secrecy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,9 +586,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rand = "0.8.5"
 termion = "1.5.6"
 argon2 = "0.4.0"
 blake3 = "1.3.1"
-secrecy = "0.8.0"
 chacha20poly1305 = { version = "0.9.0", features = ["stream"] }
 aead = "0.4.3"
 zip = { version = "0.6.2", default-features = false, features = ["deflate"] }
+zeroize = "1.3.0"

--- a/src/decrypt/crypto.rs
+++ b/src/decrypt/crypto.rs
@@ -2,6 +2,7 @@ use crate::global::crypto::DecryptStreamCiphers;
 use crate::global::parameters::{Algorithm, BenchMode, HashMode, Header, OutputFile};
 use crate::global::BLOCK_SIZE;
 use crate::key::argon2_hash;
+use crate::secret::Secret;
 use aead::stream::DecryptorLE31;
 use aead::{Aead, NewAead};
 use aes_gcm::{Aes256Gcm, Nonce};
@@ -10,7 +11,6 @@ use anyhow::Context;
 use anyhow::Result;
 use blake3::Hasher;
 use chacha20poly1305::{XChaCha20Poly1305, XNonce};
-use secrecy::{ExposeSecret, Secret};
 use std::fs::File;
 use std::io::Read;
 use std::result::Result::Ok;
@@ -33,7 +33,7 @@ pub fn decrypt_bytes_memory_mode(
     let decrypted_bytes = match header.header_type.algorithm {
         Algorithm::AesGcm => {
             let nonce = Nonce::from_slice(&header.nonce);
-            let cipher = match Aes256Gcm::new_from_slice(key.expose_secret()) {
+            let cipher = match Aes256Gcm::new_from_slice(key.expose()) {
                 Ok(cipher) => {
                     drop(key);
                     cipher
@@ -48,7 +48,7 @@ pub fn decrypt_bytes_memory_mode(
         }
         Algorithm::XChaCha20Poly1305 => {
             let nonce = XNonce::from_slice(&header.nonce);
-            let cipher = match XChaCha20Poly1305::new_from_slice(key.expose_secret()) {
+            let cipher = match XChaCha20Poly1305::new_from_slice(key.expose()) {
                 Ok(cipher) => {
                     drop(key);
                     cipher
@@ -106,7 +106,7 @@ pub fn decrypt_bytes_stream_mode(
 
     let mut streams: DecryptStreamCiphers = match header.header_type.algorithm {
         Algorithm::AesGcm => {
-            let cipher = match Aes256Gcm::new_from_slice(key.expose_secret()) {
+            let cipher = match Aes256Gcm::new_from_slice(key.expose()) {
                 Ok(cipher) => {
                     drop(key);
                     cipher
@@ -121,7 +121,7 @@ pub fn decrypt_bytes_stream_mode(
             DecryptStreamCiphers::AesGcm(Box::new(stream))
         }
         Algorithm::XChaCha20Poly1305 => {
-            let cipher = match XChaCha20Poly1305::new_from_slice(key.expose_secret()) {
+            let cipher = match XChaCha20Poly1305::new_from_slice(key.expose()) {
                 Ok(cipher) => {
                     drop(key);
                     cipher

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,9 +1,8 @@
 use crate::global::parameters::DirectoryMode;
 use crate::global::parameters::HiddenFilesMode;
 use crate::global::parameters::PrintMode;
+use crate::secret::Secret;
 use anyhow::{Context, Ok, Result};
-use secrecy::Secret;
-use secrecy::SecretVec;
 use std::fs::read_dir;
 use std::path::PathBuf;
 use std::{fs::File, io::Read};
@@ -14,7 +13,7 @@ pub fn get_bytes(name: &str) -> Result<Secret<Vec<u8>>> {
     let mut data = Vec::new();
     file.read_to_end(&mut data)
         .with_context(|| format!("Unable to read file: {}", name))?;
-    Ok(SecretVec::new(data))
+    Ok(Secret::new(data))
 }
 
 // this indexes all files/folders within a specific path

--- a/src/key.rs
+++ b/src/key.rs
@@ -11,9 +11,9 @@ use crate::secret::Secret;
 use anyhow::{Context, Result};
 use argon2::Argon2;
 use argon2::Params;
-use zeroize::Zeroize;
 use std::result::Result::Ok;
 use termion::input::TermRead;
+use zeroize::Zeroize;
 
 // this handles argon2 hashing with the provided key
 // it returns the key hashed with a specified salt

--- a/src/key.rs
+++ b/src/key.rs
@@ -7,13 +7,11 @@ use crate::global::parameters::HeaderVersion;
 use crate::global::parameters::KeyFile;
 use crate::global::parameters::PasswordMode;
 use crate::global::SALT_LEN;
+use crate::secret::Secret;
 use anyhow::{Context, Result};
 use argon2::Argon2;
 use argon2::Params;
-use secrecy::ExposeSecret;
-use secrecy::Secret;
-use secrecy::SecretVec;
-use secrecy::Zeroize;
+use zeroize::Zeroize;
 use std::result::Result::Ok;
 use termion::input::TermRead;
 
@@ -39,7 +37,7 @@ pub fn argon2_hash(
     };
 
     let argon2 = Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
-    let result = argon2.hash_password_into(raw_key.expose_secret(), salt, &mut key);
+    let result = argon2.hash_password_into(raw_key.expose(), salt, &mut key);
     drop(raw_key);
 
     if result.is_err() {
@@ -81,7 +79,7 @@ fn get_password(validation: bool) -> Result<Secret<Vec<u8>>> {
     Ok(loop {
         let input = read_password_from_stdin("Password: ").context("Unable to read password")?;
         if !validation {
-            return Ok(SecretVec::new(input.into_bytes()));
+            return Ok(Secret::new(input.into_bytes()));
         }
 
         let mut input_validation = read_password_from_stdin("Password (for validation): ")
@@ -89,7 +87,7 @@ fn get_password(validation: bool) -> Result<Secret<Vec<u8>>> {
 
         if input == input_validation && !input.is_empty() {
             input_validation.zeroize();
-            break SecretVec::new(input.into_bytes());
+            break Secret::new(input.into_bytes());
         } else if input.is_empty() {
             println!("Password cannot be empty, please try again.");
         } else {
@@ -118,7 +116,7 @@ pub fn get_secret(
         && password_mode == PasswordMode::NormalKeySourcePriority
     {
         println!("Reading key from DEXIOS_KEY environment variable");
-        SecretVec::new(
+        Secret::new(
             std::env::var("DEXIOS_KEY")
                 .context("Unable to read DEXIOS_KEY from environment variable")?
                 .into_bytes(),
@@ -126,7 +124,7 @@ pub fn get_secret(
     } else {
         get_password(validation)?
     };
-    if key.expose_secret().is_empty() {
+    if key.expose().is_empty() {
         Err(anyhow::anyhow!("The specified key is empty!"))
     } else {
         Ok(key)

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod header;
 mod key;
 mod pack;
 mod prompt;
+mod secret;
 
 // this is where subcommand/argument matching is mostly handled
 // similarly to get_matches(), this is long, clunky, and a nightmare to work with

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -8,13 +8,19 @@
 use std::fmt::Debug;
 use zeroize::Zeroize;
 
-pub struct Secret<T> where T: Zeroize {
+pub struct Secret<T>
+where
+    T: Zeroize,
+{
     hidden: T,
 }
 
-impl<T> Secret<T> where T: Zeroize {
+impl<T> Secret<T>
+where
+    T: Zeroize,
+{
     pub fn new(secret: T) -> Self {
-        Secret { hidden: secret, }
+        Secret { hidden: secret }
     }
 
     pub fn expose(&self) -> &T {
@@ -22,13 +28,19 @@ impl<T> Secret<T> where T: Zeroize {
     }
 }
 
-impl<T> Drop for Secret<T> where T: Zeroize {
+impl<T> Drop for Secret<T>
+where
+    T: Zeroize,
+{
     fn drop(&mut self) {
-        self.hidden.zeroize()
+        self.hidden.zeroize();
     }
 }
 
-impl<T> Debug for Secret<T> where T: Zeroize {
+impl<T> Debug for Secret<T>
+where
+    T: Zeroize,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("[REDACTED]")
     }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,0 +1,35 @@
+// this is a basic, auditable wrapper for secret data
+// any data stored in this type will be zeroized on drop
+// the `hidden` data can only be exposed via the `expose` function
+// this means we can prevent accidental leaking of keys/other hidden values
+// it implements debug which redacts the data to prevent leakage
+// it was inspired by the `secrecy` crate, so a huge thanks to @tarcieri (github)
+
+use std::fmt::Debug;
+use zeroize::Zeroize;
+
+pub struct Secret<T> where T: Zeroize {
+    hidden: T,
+}
+
+impl<T> Secret<T> where T: Zeroize {
+    pub fn new(secret: T) -> Self {
+        Secret { hidden: secret, }
+    }
+
+    pub fn expose(&self) -> &T {
+        &self.hidden
+    }
+}
+
+impl<T> Drop for Secret<T> where T: Zeroize {
+    fn drop(&mut self) {
+        self.hidden.zeroize()
+    }
+}
+
+impl<T> Debug for Secret<T> where T: Zeroize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}


### PR DESCRIPTION
This removes the dependency on the `secrecy` crate, by implementing the same functionality ourselves.

This was done due to a mismatch in the `zeroize` versions, and it would prevent us from adding new AEADs.