### PR TITLE
v8.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,10 +256,8 @@ dependencies = [
  "chacha20poly1305",
  "clap",
  "deoxys",
- "hmac",
  "paris",
  "rand",
- "sha3",
  "termion",
  "zeroize",
 ]
@@ -322,15 +320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,12 +328,6 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
-
-[[package]]
-name = "keccak"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "lazy_static"
@@ -468,16 +451,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
 dependencies = [
  "redox_syscall",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
-dependencies = [
- "digest",
- "keccak",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,6 @@ zeroize = "1.3.0"
 argon2 = "0.4.0"
 blake3 = "1.3.1"
 aead = { version = "0.4.3", features = ["stream"] }
-hmac = "0.12.1"
-sha3 = "0.10.1"
 rand = "0.8.5"
 
 clap = { version = "3.1.18", features = ["cargo"] }

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -35,8 +35,8 @@ pub fn memory_mode(
     let mut input_file =
         File::open(input).with_context(|| format!("Unable to open input file: {}", input))?;
 
-    let header = match header_file {
-        HeaderFile::Some(contents) => {
+    let (header, aad) = match header_file {
+            HeaderFile::Some(contents) => {
             let mut header_file = File::open(contents)
                 .with_context(|| format!("Unable to open header file: {}", input))?;
             input_file
@@ -86,6 +86,7 @@ pub fn memory_mode(
         raw_key,
         params.bench,
         params.hash_mode,
+        aad,
     )?;
     let decrypt_duration = decrypt_start_time.elapsed();
 
@@ -132,7 +133,7 @@ pub fn stream_mode(
     let mut input_file =
         File::open(input).with_context(|| format!("Unable to open input file: {}", input))?;
 
-    let header = match header_file {
+    let (header, aad) = match header_file {
         HeaderFile::Some(contents) => {
             let mut header_file = File::open(contents)
                 .with_context(|| format!("Unable to open header file: {}", input))?;
@@ -179,6 +180,7 @@ pub fn stream_mode(
         &header,
         params.bench,
         params.hash_mode,
+        aad,
     );
 
     if decryption_result.is_err() {

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -35,7 +35,7 @@ pub fn memory_mode(
     let mut input_file =
         File::open(input).with_context(|| format!("Unable to open input file: {}", input))?;
 
-    let (header, signature) = match header_file {
+    let header = match header_file {
         HeaderFile::Some(contents) => {
             let mut header_file = File::open(contents)
                 .with_context(|| format!("Unable to open header file: {}", input))?;
@@ -86,7 +86,6 @@ pub fn memory_mode(
         raw_key,
         params.bench,
         params.hash_mode,
-        signature,
     )?;
     let decrypt_duration = decrypt_start_time.elapsed();
 
@@ -133,7 +132,7 @@ pub fn stream_mode(
     let mut input_file =
         File::open(input).with_context(|| format!("Unable to open input file: {}", input))?;
 
-    let (header, signature) = match header_file {
+    let header = match header_file {
         HeaderFile::Some(contents) => {
             let mut header_file = File::open(contents)
                 .with_context(|| format!("Unable to open header file: {}", input))?;
@@ -180,7 +179,6 @@ pub fn stream_mode(
         &header,
         params.bench,
         params.hash_mode,
-        signature,
     );
 
     if decryption_result.is_err() {

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -36,7 +36,7 @@ pub fn memory_mode(
         File::open(input).with_context(|| format!("Unable to open input file: {}", input))?;
 
     let (header, aad) = match header_file {
-            HeaderFile::Some(contents) => {
+        HeaderFile::Some(contents) => {
             let mut header_file = File::open(contents)
                 .with_context(|| format!("Unable to open header file: {}", input))?;
             input_file
@@ -86,7 +86,7 @@ pub fn memory_mode(
         raw_key,
         params.bench,
         params.hash_mode,
-        aad,
+        &aad,
     )?;
     let decrypt_duration = decrypt_start_time.elapsed();
 
@@ -180,7 +180,7 @@ pub fn stream_mode(
         &header,
         params.bench,
         params.hash_mode,
-        aad,
+        &aad,
     );
 
     if decryption_result.is_err() {

--- a/src/decrypt/crypto.rs
+++ b/src/decrypt/crypto.rs
@@ -6,12 +6,12 @@ use crate::key::argon2_hash;
 use crate::secret::Secret;
 use crate::streams::init_decryption_stream;
 use aead::{NewAead, Payload};
-use aes_gcm::{Aes256Gcm};
+use aes_gcm::Aes256Gcm;
 use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
 use blake3::Hasher;
-use chacha20poly1305::{XChaCha20Poly1305};
+use chacha20poly1305::XChaCha20Poly1305;
 use deoxys::DeoxysII256;
 use paris::success;
 use std::fs::File;
@@ -38,30 +38,25 @@ pub fn decrypt_bytes_memory_mode(
     let payload = Payload { aad, msg: data };
 
     let ciphers = match header.header_type.algorithm {
-        Algorithm::Aes256Gcm => {
-            match Aes256Gcm::new_from_slice(key.expose()) {
-                Ok(cipher) => MemoryCiphers::Aes256Gcm(Box::new(cipher)),
-                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
-            }
-        }
-        Algorithm::XChaCha20Poly1305 => {
-            match XChaCha20Poly1305::new_from_slice(key.expose()) {
-                Ok(cipher) => MemoryCiphers::XChaCha(Box::new(cipher)),
-                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
-            }
-
-        }
-        Algorithm::DeoxysII256 => {
-            match DeoxysII256::new_from_slice(key.expose()) {
-                Ok(cipher) => MemoryCiphers::DeoxysII(Box::new(cipher)),
-                Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
-            }
-        }
+        Algorithm::Aes256Gcm => match Aes256Gcm::new_from_slice(key.expose()) {
+            Ok(cipher) => MemoryCiphers::Aes256Gcm(Box::new(cipher)),
+            Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
+        },
+        Algorithm::XChaCha20Poly1305 => match XChaCha20Poly1305::new_from_slice(key.expose()) {
+            Ok(cipher) => MemoryCiphers::XChaCha(Box::new(cipher)),
+            Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
+        },
+        Algorithm::DeoxysII256 => match DeoxysII256::new_from_slice(key.expose()) {
+            Ok(cipher) => MemoryCiphers::DeoxysII(Box::new(cipher)),
+            Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
+        },
     };
 
     let decrypted_bytes = match ciphers.decrypt(&header.nonce, payload) {
         Ok(decrypted_bytes) => decrypted_bytes,
-        Err(_) => return Err(anyhow!("Unable to decrypt the data. Maybe it's the wrong key, or it's not an encrypted file."))
+        Err(_) => return Err(anyhow!(
+            "Unable to decrypt the data. Maybe it's the wrong key, or it's not an encrypted file."
+        )),
     };
 
     let mut hasher = Hasher::new();

--- a/src/decrypt/crypto.rs
+++ b/src/decrypt/crypto.rs
@@ -54,9 +54,11 @@ pub fn decrypt_bytes_memory_mode(
 
     let decrypted_bytes = match ciphers.decrypt(&header.nonce, payload) {
         Ok(decrypted_bytes) => decrypted_bytes,
-        Err(_) => return Err(anyhow!(
+        Err(_) => {
+            return Err(anyhow!(
             "Unable to decrypt the data. Maybe it's the wrong key, or it's not an encrypted file."
-        )),
+        ))
+        }
     };
 
     let mut hasher = Hasher::new();

--- a/src/encrypt/crypto.rs
+++ b/src/encrypt/crypto.rs
@@ -42,6 +42,8 @@ pub fn encrypt_bytes_memory_mode(
         algorithm,
     };
 
+    let key = argon2_hash(raw_key, &salt, &header_type.header_version)?;
+
     let (header, encrypted_bytes) = match algorithm {
         Algorithm::Aes256Gcm => {
             let nonce_bytes = StdRng::from_entropy().gen::<[u8; 12]>();
@@ -52,8 +54,6 @@ pub fn encrypt_bytes_memory_mode(
                 nonce: nonce_bytes.to_vec(),
                 header_type,
             };
-
-            let key = argon2_hash(raw_key, &salt, &header.header_type.header_version)?;
 
             let aad = create_aad(&header);
 
@@ -85,8 +85,6 @@ pub fn encrypt_bytes_memory_mode(
                 header_type,
             };
 
-            let key = argon2_hash(raw_key, &salt, &header.header_type.header_version)?;
-
             let aad = create_aad(&header);
 
             let cipher = match XChaCha20Poly1305::new_from_slice(key.expose()) {
@@ -116,8 +114,6 @@ pub fn encrypt_bytes_memory_mode(
                 nonce: nonce_bytes.to_vec(),
                 header_type,
             };
-
-            let key = argon2_hash(raw_key, &salt, &header.header_type.header_version)?;
 
             let aad = create_aad(&header);
 

--- a/src/encrypt/crypto.rs
+++ b/src/encrypt/crypto.rs
@@ -52,12 +52,15 @@ pub fn encrypt_bytes_memory_mode(
 
             let key = argon2_hash(raw_key, &salt, &header.header_type.header_version)?;
 
+            let aad = get_aad(&header)?;
+
             let cipher = match Aes256Gcm::new_from_slice(key.expose()) {
                 Ok(cipher) => cipher,
                 Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
             };
 
-            let encrypted_bytes = match cipher.encrypt(nonce, data.expose().as_slice()) {
+            let payload = Payload { aad: &aad, msg: data.expose().as_slice() };
+            let encrypted_bytes = match cipher.encrypt(nonce, payload) {
                 Ok(bytes) => bytes,
                 Err(_) => return Err(anyhow!("Unable to encrypt the data")),
             };
@@ -78,12 +81,15 @@ pub fn encrypt_bytes_memory_mode(
 
             let key = argon2_hash(raw_key, &salt, &header.header_type.header_version)?;
 
+            let aad = get_aad(&header)?;
+
             let cipher = match XChaCha20Poly1305::new_from_slice(key.expose()) {
                 Ok(cipher) => cipher,
                 Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
             };
 
-            let encrypted_bytes = match cipher.encrypt(nonce, data.expose().as_slice()) {
+            let payload = Payload { aad: &aad, msg: data.expose().as_slice() };
+            let encrypted_bytes = match cipher.encrypt(nonce, payload) {
                 Ok(bytes) => bytes,
                 Err(_) => return Err(anyhow!("Unable to encrypt the data")),
             };
@@ -104,12 +110,15 @@ pub fn encrypt_bytes_memory_mode(
 
             let key = argon2_hash(raw_key, &salt, &header.header_type.header_version)?;
 
+            let aad = get_aad(&header)?;
+
             let cipher = match DeoxysII256::new_from_slice(key.expose()) {
                 Ok(cipher) => cipher,
                 Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
             };
 
-            let encrypted_bytes = match cipher.encrypt(nonce, data.expose().as_slice()) {
+            let payload = Payload { aad: &aad, msg: data.expose().as_slice() };
+            let encrypted_bytes = match cipher.encrypt(nonce, payload) {
                 Ok(bytes) => bytes,
                 Err(_) => return Err(anyhow!("Unable to encrypt the data")),
             };

--- a/src/encrypt/crypto.rs
+++ b/src/encrypt/crypto.rs
@@ -1,7 +1,7 @@
 use crate::global::enums::{Algorithm, BenchMode, CipherMode, HashMode, OutputFile};
 use crate::global::structs::{Header, HeaderType};
 use crate::global::{BLOCK_SIZE, VERSION};
-use crate::header::get_aad;
+use crate::header::create_aad;
 use crate::key::{argon2_hash, gen_salt};
 use crate::secret::Secret;
 use crate::streams::init_encryption_stream;
@@ -52,7 +52,7 @@ pub fn encrypt_bytes_memory_mode(
 
             let key = argon2_hash(raw_key, &salt, &header.header_type.header_version)?;
 
-            let aad = get_aad(&header)?;
+            let aad = create_aad(&header)?;
 
             let cipher = match Aes256Gcm::new_from_slice(key.expose()) {
                 Ok(cipher) => cipher,
@@ -81,7 +81,7 @@ pub fn encrypt_bytes_memory_mode(
 
             let key = argon2_hash(raw_key, &salt, &header.header_type.header_version)?;
 
-            let aad = get_aad(&header)?;
+            let aad = create_aad(&header)?;
 
             let cipher = match XChaCha20Poly1305::new_from_slice(key.expose()) {
                 Ok(cipher) => cipher,
@@ -110,7 +110,7 @@ pub fn encrypt_bytes_memory_mode(
 
             let key = argon2_hash(raw_key, &salt, &header.header_type.header_version)?;
 
-            let aad = get_aad(&header)?;
+            let aad = create_aad(&header)?;
 
             let cipher = match DeoxysII256::new_from_slice(key.expose()) {
                 Ok(cipher) => cipher,
@@ -185,7 +185,7 @@ pub fn encrypt_bytes_stream_mode(
         crate::header::hash(&mut hasher, &header);
     }
 
-    let aad = get_aad(&header)?;
+    let aad = create_aad(&header)?;
 
     let mut buffer = vec![0u8; BLOCK_SIZE].into_boxed_slice();
 
@@ -195,7 +195,7 @@ pub fn encrypt_bytes_stream_mode(
             .context("Unable to read from the input file")?;
         if read_count == BLOCK_SIZE {
             // aad is just empty bytes normally
-            // get_aad returns empty bytes if the header isn't V3+
+            // create_aad returns empty bytes if the header isn't V3+
             // this means we don't need to do anything special in regards to older versions
             let payload = Payload { aad: &aad, msg: buffer.as_ref() };
 

--- a/src/encrypt/crypto.rs
+++ b/src/encrypt/crypto.rs
@@ -1,4 +1,4 @@
-use crate::global::crypto::EncryptMemoryCiphers;
+use crate::global::crypto::MemoryCiphers;
 use crate::global::enums::{Algorithm, BenchMode, CipherMode, HashMode, OutputFile};
 use crate::global::structs::{Header, HeaderType};
 use crate::global::{BLOCK_SIZE, VERSION};
@@ -61,7 +61,7 @@ pub fn encrypt_bytes_memory_mode(
             };
 
 
-            (header, EncryptMemoryCiphers::Aes256Gcm(Box::new(cipher)))
+            (header, MemoryCiphers::Aes256Gcm(Box::new(cipher)))
         }
         Algorithm::XChaCha20Poly1305 => {
             let nonce_bytes = StdRng::from_entropy().gen::<[u8; 24]>();
@@ -77,7 +77,7 @@ pub fn encrypt_bytes_memory_mode(
                 Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
             };
 
-            (header, EncryptMemoryCiphers::XChaCha(Box::new(cipher)))
+            (header, MemoryCiphers::XChaCha(Box::new(cipher)))
         }
         Algorithm::DeoxysII256 => {
             let nonce_bytes = StdRng::from_entropy().gen::<[u8; 15]>();
@@ -93,7 +93,7 @@ pub fn encrypt_bytes_memory_mode(
                 Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
             };
 
-            (header, EncryptMemoryCiphers::DeoxysII(Box::new(cipher)))
+            (header, MemoryCiphers::DeoxysII(Box::new(cipher)))
         }
     };
 

--- a/src/encrypt/crypto.rs
+++ b/src/encrypt/crypto.rs
@@ -7,11 +7,11 @@ use crate::key::{argon2_hash, gen_salt};
 use crate::secret::Secret;
 use crate::streams::init_encryption_stream;
 use aead::{NewAead, Payload};
-use aes_gcm::{Aes256Gcm};
+use aes_gcm::Aes256Gcm;
 use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
-use chacha20poly1305::{XChaCha20Poly1305};
+use chacha20poly1305::XChaCha20Poly1305;
 use deoxys::DeoxysII256;
 use paris::success;
 use rand::{prelude::StdRng, Rng, SeedableRng};
@@ -59,7 +59,6 @@ pub fn encrypt_bytes_memory_mode(
                 Ok(cipher) => cipher,
                 Err(_) => return Err(anyhow!("Unable to create cipher with argon2id hashed key.")),
             };
-
 
             (header, MemoryCiphers::Aes256Gcm(Box::new(cipher)))
         }

--- a/src/global.rs
+++ b/src/global.rs
@@ -4,7 +4,7 @@ use self::enums::{Algorithm, HeaderVersion};
 // these can be customised easily by anyone to suit their own needs
 pub const BLOCK_SIZE: usize = 1_048_576; // 1024*1024 bytes
 pub const SALT_LEN: usize = 16; // bytes
-pub const VERSION: HeaderVersion = HeaderVersion::V2;
+pub const VERSION: HeaderVersion = HeaderVersion::V3;
 
 pub const ALGORITHMS: [Algorithm; 3] = [
     Algorithm::XChaCha20Poly1305,

--- a/src/global/crypto.rs
+++ b/src/global/crypto.rs
@@ -5,7 +5,7 @@
 
 use aead::{
     stream::{DecryptorLE31, EncryptorLE31},
-    Payload, Aead,
+    Aead, Payload,
 };
 use aes_gcm::Aes256Gcm;
 use chacha20poly1305::XChaCha20Poly1305;

--- a/src/global/crypto.rs
+++ b/src/global/crypto.rs
@@ -11,22 +11,33 @@ use aes_gcm::Aes256Gcm;
 use chacha20poly1305::XChaCha20Poly1305;
 use deoxys::DeoxysII256;
 
-pub enum EncryptMemoryCiphers {
+pub enum MemoryCiphers {
     Aes256Gcm(Box<Aes256Gcm>),
     XChaCha(Box<XChaCha20Poly1305>),
     DeoxysII(Box<DeoxysII256>),
 }
 
-impl EncryptMemoryCiphers {
+impl MemoryCiphers {
     pub fn encrypt<'msg, 'aad>(
         &self,
         nonce: &[u8],
         plaintext: impl Into<Payload<'msg, 'aad>>,
     ) -> aead::Result<Vec<u8>> {
         match self {
-            EncryptMemoryCiphers::Aes256Gcm(c) => c.encrypt(nonce.as_ref().into(), plaintext),
-            EncryptMemoryCiphers::XChaCha(c) => c.encrypt(nonce.as_ref().into(), plaintext),
-            EncryptMemoryCiphers::DeoxysII(c) => c.encrypt(nonce.as_ref().into(), plaintext),
+            MemoryCiphers::Aes256Gcm(c) => c.encrypt(nonce.as_ref().into(), plaintext),
+            MemoryCiphers::XChaCha(c) => c.encrypt(nonce.as_ref().into(), plaintext),
+            MemoryCiphers::DeoxysII(c) => c.encrypt(nonce.as_ref().into(), plaintext),
+        }
+    }
+    pub fn decrypt<'msg, 'aad>(
+        &self,
+        nonce: &[u8],
+        ciphertext: impl Into<Payload<'msg, 'aad>>,
+    ) -> aead::Result<Vec<u8>> {
+        match self {
+            MemoryCiphers::Aes256Gcm(c) => c.decrypt(nonce.as_ref().into(), ciphertext),
+            MemoryCiphers::XChaCha(c) => c.decrypt(nonce.as_ref().into(), ciphertext),
+            MemoryCiphers::DeoxysII(c) => c.decrypt(nonce.as_ref().into(), ciphertext),
         }
     }
 }

--- a/src/global/crypto.rs
+++ b/src/global/crypto.rs
@@ -5,11 +5,31 @@
 
 use aead::{
     stream::{DecryptorLE31, EncryptorLE31},
-    Payload,
+    Payload, Aead,
 };
 use aes_gcm::Aes256Gcm;
 use chacha20poly1305::XChaCha20Poly1305;
 use deoxys::DeoxysII256;
+
+pub enum EncryptMemoryCiphers {
+    Aes256Gcm(Box<Aes256Gcm>),
+    XChaCha(Box<XChaCha20Poly1305>),
+    DeoxysII(Box<DeoxysII256>),
+}
+
+impl EncryptMemoryCiphers {
+    pub fn encrypt<'msg, 'aad>(
+        &self,
+        nonce: &[u8],
+        plaintext: impl Into<Payload<'msg, 'aad>>,
+    ) -> aead::Result<Vec<u8>> {
+        match self {
+            EncryptMemoryCiphers::Aes256Gcm(c) => c.encrypt(nonce.as_ref().into(), plaintext),
+            EncryptMemoryCiphers::XChaCha(c) => c.encrypt(nonce.as_ref().into(), plaintext),
+            EncryptMemoryCiphers::DeoxysII(c) => c.encrypt(nonce.as_ref().into(), plaintext),
+        }
+    }
+}
 
 pub enum EncryptStreamCiphers {
     Aes256Gcm(Box<EncryptorLE31<Aes256Gcm>>),

--- a/src/global/enums.rs
+++ b/src/global/enums.rs
@@ -64,6 +64,7 @@ pub enum CipherMode {
 pub enum HeaderVersion {
     V1,
     V2,
+    V3,
 }
 
 #[derive(Copy, Clone)]

--- a/src/header.rs
+++ b/src/header.rs
@@ -266,11 +266,6 @@ pub fn read_from_file(file: &mut File) -> Result<(Header, Vec<u8>)> {
             file.read_exact(&mut padding2)
                 .context("Unable to read final padding from header")?; // read and discard the final padding
 
-            // need to read the padding into padding1 and padding2 - done
-            // and then pass it to read_aad
-            // get_aad needs reverting to include extra 0s (or random bytes) - done
-            // this function should return aad, whether it's Vec::new() or actual bytes
-
             let header = Header {
                 header_type: header_info,
                 nonce,

--- a/src/header.rs
+++ b/src/header.rs
@@ -74,10 +74,7 @@ fn serialize(header_info: &HeaderType) -> ([u8; 2], [u8; 2], [u8; 2]) {
 // this writes a header to a file
 // it handles padding and serialising the specific information
 // it ensures the buffer is left at 64 bytes, so other functions can write the data without further hassle
-pub fn write_to_file(
-    file: &mut OutputFile,
-    header: &Header,
-) -> Result<()> {
+pub fn write_to_file(file: &mut OutputFile, header: &Header) -> Result<()> {
     let nonce_len = calc_nonce_len(&header.header_type);
 
     match &header.header_type.header_version {

--- a/src/header.rs
+++ b/src/header.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use blake3::Hasher;
-use paris::{Logger, warn};
+use paris::{warn, Logger};
 use std::{fs::File, io::Write};
 use std::{fs::OpenOptions, io::Read, process::exit};
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -124,18 +124,13 @@ pub fn write_to_file(file: &mut OutputFile, header: &Header) -> Result<()> {
 pub fn get_aad(header: &Header) -> Result<Vec<u8>> {
     match header.header_type.header_version {
         HeaderVersion::V3 => {
-            let nonce_len = calc_nonce_len(&header.header_type);
-
             let (version_info, algorithm_info, mode_info) = serialize(&header.header_type);
 
             let mut header_bytes = version_info.to_vec();
             header_bytes.extend_from_slice(&mode_info);
             header_bytes.extend_from_slice(&algorithm_info);
             header_bytes.extend_from_slice(&header.salt);
-            header_bytes.extend_from_slice(&vec![0; 16]);
             header_bytes.extend_from_slice(&header.nonce);
-            header_bytes.extend_from_slice(&vec![0u8; 26 - nonce_len]);
-
             Ok(header_bytes)
         }
         _ => (

--- a/src/header.rs
+++ b/src/header.rs
@@ -204,7 +204,7 @@ pub fn read_from_file(file: &mut File) -> Result<(Header, Vec<u8>)> {
     let header_info = deserialize(version_info, algorithm_info, mode_info)?;
     match header_info.header_version {
         HeaderVersion::V1 => {
-            warn!("You are using an older version of the Dexios header standard, please run \"dexios update\" to update your files");
+            warn!("You are using an older version of the Dexios header standard, please re-encrypt your files at your earliest convenience");
             let nonce_len = calc_nonce_len(&header_info);
             let mut nonce = vec![0u8; nonce_len];
 
@@ -228,7 +228,7 @@ pub fn read_from_file(file: &mut File) -> Result<(Header, Vec<u8>)> {
             Ok((header, aad))
         }
         HeaderVersion::V2 => {
-            warn!("You are using an older version of the Dexios header standard, please run \"dexios update\" to update your files");
+            warn!("You are using an older version of the Dexios header standard, please re-encrypt your files at your earliest convenience");
             let nonce_len = calc_nonce_len(&header_info);
             let mut nonce = vec![0u8; nonce_len];
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -3,13 +3,10 @@ use crate::{
     global::structs::{Header, HeaderType},
     global::SALT_LEN,
     prompt::{get_answer, overwrite_check},
-    secret::Secret,
 };
 use anyhow::{Context, Result};
 use blake3::Hasher;
-use hmac::{Hmac, Mac};
 use paris::Logger;
-use sha3::Sha3_512;
 use std::{fs::File, io::Write};
 use std::{fs::OpenOptions, io::Read, process::exit};
 
@@ -38,6 +35,10 @@ fn serialize(header_info: &HeaderType) -> ([u8; 2], [u8; 2], [u8; 2]) {
         }
         HeaderVersion::V2 => {
             let info: [u8; 2] = [0xDE, 0x02];
+            info
+        }
+        HeaderVersion::V3 => {
+            let info: [u8; 2] = [0xDE, 0x03];
             info
         }
     };
@@ -76,7 +77,6 @@ fn serialize(header_info: &HeaderType) -> ([u8; 2], [u8; 2], [u8; 2]) {
 pub fn write_to_file(
     file: &mut OutputFile,
     header: &Header,
-    signature: Option<Vec<u8>>,
 ) -> Result<()> {
     let nonce_len = calc_nonce_len(&header.header_type);
 
@@ -103,8 +103,6 @@ pub fn write_to_file(
         HeaderVersion::V2 => {
             let padding = vec![0u8; 26 - nonce_len];
             let (version_info, algorithm_info, mode_info) = serialize(&header.header_type);
-            // let signature = sign(header)?;
-            let signature = signature.unwrap();
 
             file.write_all(&version_info)
                 .context("Unable to write version to header")?;
@@ -118,71 +116,35 @@ pub fn write_to_file(
                 .context("Unable to write nonce to header")?; // (26 - nonce len)
             file.write_all(&padding)
                 .context("Unable to write final padding to header")?; // this has reached 48 bytes
-            file.write_all(&signature)
+            file.write_all(&[0u8; 16])
                 .context("Unable to write signature to header")?; // signature
+        }
+        HeaderVersion::V3 => {
+            let padding = vec![0u8; 26 - nonce_len];
+            let (version_info, algorithm_info, mode_info) = serialize(&header.header_type);
+
+            file.write_all(&version_info)
+                .context("Unable to write version to header")?;
+            file.write_all(&algorithm_info)
+                .context("Unable to write algorithm to header")?;
+            file.write_all(&mode_info)
+                .context("Unable to write encryption mode to header")?; // 6 bytes total
+            file.write_all(&header.salt)
+                .context("Unable to write salt to header")?; // 22 bytes total
+            file.write_all(&[0; 16])
+                .context("Unable to write empty bytes to header")?; // 38 bytes total (26 remaining)
+            file.write_all(&header.nonce)
+                .context("Unable to write nonce to header")?; // (26 - nonce_len remaining)
+            file.write_all(&padding)
+                .context("Unable to write final padding to header")?; // this has reached the 64 bytes
         }
     }
 
     Ok(())
 }
 
-// sign a header struct to prevent tampering
-// this is used when encrypting
-pub fn sign(header: &Header, key: Secret<[u8; 32]>) -> Result<Vec<u8>> {
-    type HmacSha3_512 = Hmac<Sha3_512>;
-    let mut mac =
-        HmacSha3_512::new_from_slice(key.expose()).context("Unable to initialise HMAC function")?; // add user's argon2 hashed key
-
-    drop(key);
-
-    let nonce_len = calc_nonce_len(&header.header_type);
-    let padding = vec![0u8; 26 - nonce_len];
-    let (version_info, algorithm_info, mode_info) = serialize(&header.header_type);
-
-    mac.update(&version_info);
-    mac.update(&algorithm_info);
-    mac.update(&mode_info);
-    mac.update(&header.salt);
-    mac.update(&header.nonce);
-    mac.update(&padding);
-
-    let signature = mac.finalize().into_bytes();
-
-    Ok(signature[..16].to_vec())
-}
-
-// verify a header struct to ensure it matches the signature
-// this is used when decrypting
-// if the signature doesn't match, dexios will not decrypt
-pub fn verify(header: &Header, signature: Option<Vec<u8>>, key: Secret<[u8; 32]>) -> Result<bool> {
-    type HmacSha3_512 = Hmac<Sha3_512>;
-    let mut mac =
-        HmacSha3_512::new_from_slice(key.expose()).context("Unable to initialise HMAC function")?; // add user's argon2 hashed key
-
-    drop(key);
-
-    let nonce_len = calc_nonce_len(&header.header_type);
-    let padding = vec![0u8; 26 - nonce_len];
-    let (version_info, algorithm_info, mode_info) = serialize(&header.header_type);
-
-    mac.update(&version_info);
-    mac.update(&algorithm_info);
-    mac.update(&mode_info);
-    mac.update(&header.salt);
-    mac.update(&header.nonce);
-    mac.update(&padding);
-
-    let signature_verif = mac.finalize().into_bytes();
-
-    if signature.unwrap() == signature_verif[..16] {
-        Ok(true)
-    } else {
-        Ok(false)
-    }
-}
-
 // this hashes a header with the salt, nonce, and info provided
-pub fn hash(hasher: &mut Hasher, header: &Header, signature: Option<Vec<u8>>) {
+pub fn hash(hasher: &mut Hasher, header: &Header) {
     match &header.header_type.header_version {
         HeaderVersion::V1 => {
             let nonce_len = calc_nonce_len(&header.header_type);
@@ -208,7 +170,19 @@ pub fn hash(hasher: &mut Hasher, header: &Header, signature: Option<Vec<u8>>) {
             hasher.update(&header.salt);
             hasher.update(&header.nonce);
             hasher.update(&padding);
-            hasher.update(&signature.unwrap());
+        }
+        HeaderVersion::V3 => {
+            let nonce_len = calc_nonce_len(&header.header_type);
+            let padding = vec![0u8; 26 - nonce_len];
+            let (version_info, algorithm_info, mode_info) = serialize(&header.header_type);
+
+            hasher.update(&version_info);
+            hasher.update(&algorithm_info);
+            hasher.update(&mode_info);
+            hasher.update(&header.salt);
+            hasher.update(&[0; 16]);
+            hasher.update(&header.nonce);
+            hasher.update(&padding);
         }
     }
 }
@@ -223,6 +197,7 @@ fn deserialize(
     let header_version = match version_info {
         [0xDE, 0x01] => HeaderVersion::V1,
         [0xDE, 0x02] => HeaderVersion::V2,
+        [0xDE, 0x03] => HeaderVersion::V3,
         _ => return Err(anyhow::anyhow!("Error getting cipher mode from header")),
     };
 
@@ -248,7 +223,7 @@ fn deserialize(
 
 // this takes an input file, and gets all of the data necessary from the header of the file
 // it ensures that the buffer starts at 64 bytes, so that other functions can just read encrypted data immediately
-pub fn read_from_file(file: &mut File) -> Result<(Header, Option<Vec<u8>>)> {
+pub fn read_from_file(file: &mut File) -> Result<Header> {
     let mut version_info = [0u8; 2];
     let mut algorithm_info = [0u8; 2];
     let mut mode_info = [0u8; 2];
@@ -276,19 +251,17 @@ pub fn read_from_file(file: &mut File) -> Result<(Header, Option<Vec<u8>>)> {
             file.read_exact(&mut vec![0u8; 26 - nonce_len])
                 .context("Unable to read final padding from header")?; // read and discard the final padding
 
-            Ok((
-                Header {
-                    header_type: header_info,
-                    nonce,
-                    salt,
-                },
-                None,
-            ))
+            let header = Header {
+                header_type: header_info,
+                nonce,
+                salt,
+            };
+
+            Ok(header)
         }
         HeaderVersion::V2 => {
             let nonce_len = calc_nonce_len(&header_info);
             let mut nonce = vec![0u8; nonce_len];
-            let mut signature = [0u8; 16];
 
             file.read_exact(&mut salt)
                 .context("Unable to read salt from header")?;
@@ -296,7 +269,7 @@ pub fn read_from_file(file: &mut File) -> Result<(Header, Option<Vec<u8>>)> {
                 .context("Unable to read nonce from header")?;
             file.read_exact(&mut vec![0u8; 26 - nonce_len])
                 .context("Unable to read final padding from header")?; // read and discard the padding
-            file.read_exact(&mut signature)
+            file.read_exact(&mut [0u8; 16])
                 .context("Unable to read signature from header")?; // read signature
 
             let header = Header {
@@ -305,7 +278,28 @@ pub fn read_from_file(file: &mut File) -> Result<(Header, Option<Vec<u8>>)> {
                 salt,
             };
 
-            Ok((header, Some(signature.to_vec())))
+            Ok(header)
+        }
+        HeaderVersion::V3 => {
+            let nonce_len = calc_nonce_len(&header_info);
+            let mut nonce = vec![0u8; nonce_len];
+
+            file.read_exact(&mut salt)
+                .context("Unable to read salt from header")?;
+            file.read_exact(&mut [0; 16])
+                .context("Unable to read empty bytes from header")?; // read and subsequently discard the next 16 bytes
+            file.read_exact(&mut nonce)
+                .context("Unable to read nonce from header")?;
+            file.read_exact(&mut vec![0u8; 26 - nonce_len])
+                .context("Unable to read final padding from header")?; // read and discard the final padding
+
+            let header = Header {
+                header_type: header_info,
+                nonce,
+                salt,
+            };
+
+            Ok(header)
         }
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -222,7 +222,7 @@ pub fn read_from_file(file: &mut File) -> Result<(Header, Vec<u8>)> {
                 salt,
             };
 
-            let aad = get_aad(&header, None, None)?;
+            let aad = get_aad(&header, None, None);
 
             Ok((header, aad))
         }
@@ -245,7 +245,7 @@ pub fn read_from_file(file: &mut File) -> Result<(Header, Vec<u8>)> {
                 salt,
             };
 
-            let aad = get_aad(&header, None, None)?;
+            let aad = get_aad(&header, None, None);
 
             Ok((header, aad))
         }
@@ -275,14 +275,14 @@ pub fn read_from_file(file: &mut File) -> Result<(Header, Vec<u8>)> {
                 salt,
             };
 
-            let aad = get_aad(&header, Some(padding1), Some(padding2))?;
+            let aad = get_aad(&header, Some(padding1), Some(padding2));
 
             Ok((header, aad))
         }
     }
 }
 
-pub fn get_aad(header: &Header, padding1: Option<[u8; 16]>, padding2: Option<Vec<u8>>) -> Result<Vec<u8>> {
+pub fn get_aad(header: &Header, padding1: Option<[u8; 16]>, padding2: Option<Vec<u8>>) -> Vec<u8> {
     match header.header_type.header_version {
         HeaderVersion::V3 => {
             let (version_info, algorithm_info, mode_info) = serialize(&header.header_type);
@@ -294,15 +294,13 @@ pub fn get_aad(header: &Header, padding1: Option<[u8; 16]>, padding2: Option<Vec
             header_bytes.extend_from_slice(&padding1.unwrap());
             header_bytes.extend_from_slice(&header.nonce);
             header_bytes.extend_from_slice(&padding2.unwrap());
-            Ok(header_bytes)
+            header_bytes
         }
-        _ => (
-            Ok(Vec::new())
-        )
+        _ => Vec::new(),
     }
 }
 
-pub fn create_aad(header: &Header) -> Result<Vec<u8>> {
+pub fn create_aad(header: &Header) -> Vec<u8> {
     match header.header_type.header_version {
         HeaderVersion::V3 => {
             let nonce_len = calc_nonce_len(&header.header_type);
@@ -315,11 +313,9 @@ pub fn create_aad(header: &Header) -> Result<Vec<u8>> {
             header_bytes.extend_from_slice(&[0; 16]);
             header_bytes.extend_from_slice(&header.nonce);
             header_bytes.extend_from_slice(&vec![0; 26 - nonce_len]);
-            Ok(header_bytes)
+            header_bytes
         }
-        _ => (
-            Ok(Vec::new())
-        )
+        _ => Vec::new(),
     }
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -121,6 +121,29 @@ pub fn write_to_file(file: &mut OutputFile, header: &Header) -> Result<()> {
     Ok(())
 }
 
+pub fn get_aad(header: &Header) -> Result<Vec<u8>> {
+    match header.header_type.header_version {
+        HeaderVersion::V3 => {
+            let nonce_len = calc_nonce_len(&header.header_type);
+
+            let (version_info, algorithm_info, mode_info) = serialize(&header.header_type);
+
+            let mut header_bytes = version_info.to_vec();
+            header_bytes.extend_from_slice(&mode_info);
+            header_bytes.extend_from_slice(&algorithm_info);
+            header_bytes.extend_from_slice(&header.salt);
+            header_bytes.extend_from_slice(&vec![0; 16]);
+            header_bytes.extend_from_slice(&header.nonce);
+            header_bytes.extend_from_slice(&vec![0u8; 26 - nonce_len]);
+
+            Ok(header_bytes)
+        }
+        _ => (
+            Ok(Vec::new())
+        )
+    }
+}
+
 // this hashes a header with the salt, nonce, and info provided
 pub fn hash(hasher: &mut Hasher, header: &Header) {
     match &header.header_type.header_version {

--- a/src/header.rs
+++ b/src/header.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use blake3::Hasher;
-use paris::Logger;
+use paris::{Logger, warn};
 use std::{fs::File, io::Write};
 use std::{fs::OpenOptions, io::Read, process::exit};
 
@@ -204,6 +204,7 @@ pub fn read_from_file(file: &mut File) -> Result<(Header, Vec<u8>)> {
     let header_info = deserialize(version_info, algorithm_info, mode_info)?;
     match header_info.header_version {
         HeaderVersion::V1 => {
+            warn!("You are using an older version of the Dexios header standard, please run \"dexios update\" to update your files");
             let nonce_len = calc_nonce_len(&header_info);
             let mut nonce = vec![0u8; nonce_len];
 
@@ -227,6 +228,7 @@ pub fn read_from_file(file: &mut File) -> Result<(Header, Vec<u8>)> {
             Ok((header, aad))
         }
         HeaderVersion::V2 => {
+            warn!("You are using an older version of the Dexios header standard, please run \"dexios update\" to update your files");
             let nonce_len = calc_nonce_len(&header_info);
             let mut nonce = vec![0u8; nonce_len];
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -62,8 +62,8 @@ pub fn argon2_hash(
             }
         }
         HeaderVersion::V3 => {
-            // 512MiB of memory, 10 iterations, 4 levels of parallelism
-            let params = Params::new(524_288, 10, 4, Some(Params::DEFAULT_OUTPUT_LEN));
+            // 256MiB of memory, 10 iterations, 4 levels of parallelism
+            let params = Params::new(262_144, 10, 4, Some(Params::DEFAULT_OUTPUT_LEN));
             match params {
                 std::result::Result::Ok(parameters) => parameters,
                 Err(_) => return Err(anyhow::anyhow!("Error initialising argon2id parameters")),

--- a/src/key.rs
+++ b/src/key.rs
@@ -61,6 +61,14 @@ pub fn argon2_hash(
                 Err(_) => return Err(anyhow::anyhow!("Error initialising argon2id parameters")),
             }
         }
+        HeaderVersion::V3 => {
+            // 512MiB of memory, 10 iterations, 4 levels of parallelism
+            let params = Params::new(524_288, 10, 4, Some(Params::DEFAULT_OUTPUT_LEN));
+            match params {
+                std::result::Result::Ok(parameters) => parameters,
+                Err(_) => return Err(anyhow::anyhow!("Error initialising argon2id parameters")),
+            }
+        }
     };
 
     let hash_start_time = Instant::now();

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -43,10 +43,7 @@ pub fn init_encryption_stream(
             };
 
             let stream = EncryptorLE31::from_aead(cipher, nonce_bytes.as_slice().into());
-            Ok((
-                EncryptStreamCiphers::Aes256Gcm(Box::new(stream)),
-                header,
-            ))
+            Ok((EncryptStreamCiphers::Aes256Gcm(Box::new(stream)), header))
         }
         Algorithm::XChaCha20Poly1305 => {
             let nonce_bytes = StdRng::from_entropy().gen::<[u8; 20]>();
@@ -63,10 +60,7 @@ pub fn init_encryption_stream(
             };
 
             let stream = EncryptorLE31::from_aead(cipher, nonce_bytes.as_slice().into());
-            Ok((
-                EncryptStreamCiphers::XChaCha(Box::new(stream)),
-                header,
-            ))
+            Ok((EncryptStreamCiphers::XChaCha(Box::new(stream)), header))
         }
         Algorithm::DeoxysII256 => {
             let nonce_bytes = StdRng::from_entropy().gen::<[u8; 11]>();
@@ -83,10 +77,7 @@ pub fn init_encryption_stream(
             };
 
             let stream = EncryptorLE31::from_aead(cipher, nonce_bytes.as_slice().into());
-            Ok((
-                EncryptStreamCiphers::DeoxysII(Box::new(stream)),
-                header,
-            ))
+            Ok((EncryptStreamCiphers::DeoxysII(Box::new(stream)), header))
         }
     }
 }


### PR DESCRIPTION
This branch changes a fair amount!

In order to cleanup the code base, HMAC and SHA3 were removed as dependencies. I have decided to migrate the header authentication over to the "associated data" half of AEADs, and I'm not too sure why I didn't go that route in the first place.

V2 Headers will still be able to be decrypted, and are still supported. Any files encrypted after this change will use AAD as opposed to SHA3-512 HMAC.

I have also added a note alerting users that their files use an older header version, and to re-encrypt at the earliest possible convenience.

Along with these changes, I have also *marginally* increased the `argon2id` key derivation parameters.

Memory-mode code is now enum-based, similarly to streaming modes, so the code is a lot cleaner.

The process has also been started to remove `RUSTFLAGS` mentions everywhere, as I was going from [outdated information](https://github.com/RustCrypto/AEADs/issues/427). Binaries will also no longer be built with these flags, which means they will be supported on even more devices.