### PR TITLE
Add Pack Mode

### DIFF
--- a/.github/workflows/dexios-tests.yml
+++ b/.github/workflows/dexios-tests.yml
@@ -193,3 +193,29 @@ jobs:
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -eHyk keyfile --aead 3 1KB.bin 1KB.enc
     - name: Decrypt 1KB file (Deoxys-II-256)
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -dHyk keyfile 1KB.enc 1KB.bin
+  pack:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Retrieve Dexios
+      uses: actions/download-artifact@v3
+      with:
+        name: dexios
+        path: target/release/dexios
+    - name: Make Binary Executable
+      run: chmod +x /home/runner/work/dexios/dexios/target/release/dexios/dexios
+    - name: Make Directory
+      run: mkdir test
+    - name: Generate test files
+      run: dd if=/dev/urandom of=test/1.bin bs=1M count=10 && dd if=/dev/urandom of=test/2.bin bs=1M count=10 && dd if=/dev/urandom of=test/3.bin bs=1M count=10 && dd if=/dev/urandom of=test/4.bin bs=1M count=10
+    - name: Generate keyfile
+      run: dd if=/dev/urandom of=keyfile bs=1 count=4096
+    - name: Pack+Encrypt test directory with exclude (XChaCha20-Poly1305)
+      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios pack --exclude="1.bin" -eyk keyfile --aead 1 test/ output.zip
+    - name: Remove Directory
+      run: rm -rf test/
+    - name: Decrypt+Unpack archive (XChaCha20-Poly1305)
+      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios pack -dyk keyfile output.zip .
+    - name: List files in directory
+      run: ls -lla test/

--- a/.github/workflows/dexios-tests.yml
+++ b/.github/workflows/dexios-tests.yml
@@ -212,10 +212,10 @@ jobs:
     - name: Generate keyfile
       run: dd if=/dev/urandom of=keyfile bs=1 count=4096
     - name: Pack+Encrypt test directory with exclude (XChaCha20-Poly1305)
-      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios pack --exclude="1.bin" -eyk keyfile --aead 1 test/ output.zip
+      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios pack --exclude="1.bin" -yk keyfile --aead 1 test/ output.zip
     - name: Remove Directory
       run: rm -rf test/
     - name: Decrypt+Unpack archive (XChaCha20-Poly1305)
-      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios pack -dyk keyfile output.zip .
+      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios unpack -yk keyfile output.zip .
     - name: List files in directory
       run: ls -lla test/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +220,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +280,7 @@ dependencies = [
  "paris",
  "rand",
  "termion",
+ "zip",
 ]
 
 [[package]]
@@ -567,3 +593,14 @@ name = "zeroize"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+
+[[package]]
+name = "zip"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,7 @@ clap = { version = "3.1.18", features = ["cargo"] }
 anyhow = "1.0.57"
 paris = { version = "1.5.13", features = ["macros"] }
 
+zip = { version = "0.6.2", default-features = false }
+
 [target.'cfg(unix)'.dependencies]
 termion = "1.5.6"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Versions 6 and above will receive security updates, and they will be backported depending on the vulnerability severity.
+Versions 7 and above will receive security updates, and they will be backported depending on the vulnerability severity.
 
 | Version | Supported          |
 | ------- | ------------------ |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -286,6 +286,79 @@ pub fn get_matches() -> clap::ArgMatches {
             )
         )
         .subcommand(
+            Command::new("unpack")
+                .short_flag('u')
+                .about("Unpack a previously-packed file")
+                .arg(
+                    Arg::new("input")
+                        .value_name("input")
+                        .takes_value(true)
+                        .required(true)
+                        .help("The file to decrypt"),
+                )
+                .arg(
+                    Arg::new("output")
+                        .value_name("output")
+                        .takes_value(true)
+                        .required(true)
+                        .help("The output file"),
+                )
+                .arg(
+                    Arg::new("keyfile")
+                        .short('k')
+                        .long("keyfile")
+                        .value_name("file")
+                        .takes_value(true)
+                        .help("Use a keyfile instead of a password"),
+                )
+                .arg(
+                    Arg::new("header")
+                        .long("header")
+                        .value_name("file")
+                        .takes_value(true)
+                        .help("Use a header file that was dumped"),
+                )
+                .arg(
+                    Arg::new("erase")
+                        .long("erase")
+                        .value_name("# of passes")
+                        .takes_value(true)
+                        .require_equals(true)
+                        .help("Securely erase the input file once complete (default is 2 passes)")
+                        .min_values(0)
+                        .default_missing_value("2"),
+                )
+                .arg(
+                    Arg::new("verbose")
+                        .short('v')
+                        .long("verbose")
+                        .takes_value(false)
+                        .help("Show a detailed output"),
+                )
+                .arg(
+                    Arg::new("hash")
+                        .short('H')
+                        .long("hash")
+                        .takes_value(false)
+                        .help("Return a BLAKE3 hash of the encrypted file"),
+                )
+                .arg(
+                    Arg::new("skip")
+                        .short('y')
+                        .long("skip")
+                        .takes_value(false)
+                        .help("Skip all prompts"),
+                )
+                .arg(
+                    Arg::new("password")
+                        .short('p')
+                        .long("password")
+                        .takes_value(false)
+                        .help("Interactively ask for your password")
+                        .conflicts_with("keyfile"),
+                ),
+        )
+        .subcommand(
             Command::new("header")
                 .about("Manipulate encrypted headers (for advanced users)")
                 .subcommand_required(true)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -227,6 +227,16 @@ pub fn get_matches() -> clap::ArgMatches {
                     .help("Include hidden files"),
             )
             .arg(
+                Arg::new("exclude")
+                    .long("exclude")
+                    .value_name("pattern to exclude")
+                    .takes_value(true)
+                    .require_equals(true)
+                    .help("Exclude a file/folder (e.g. --exclude=\"Documents\") (encrypt mode only)")
+                    .min_values(0)
+                    .multiple_occurrences(true),
+            )
+            .arg(
                 Arg::new("keyfile")
                     .short('k')
                     .long("keyfile")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -189,6 +189,93 @@ pub fn get_matches() -> clap::ArgMatches {
                 ),
         )
         .subcommand(
+            Command::new("pack")
+            .about("Pack and encrypt an entire directory")
+            .short_flag('p')
+            .arg(
+                Arg::new("input")
+                    .value_name("input")
+                    .takes_value(true)
+                    .required(true)
+                    .help("The directory to encrypt"),
+            )
+            .arg(
+                Arg::new("output")
+                    .value_name("output")
+                    .takes_value(true)
+                    .required(true)
+                    .help("The output file"),
+            )
+            .arg(
+                Arg::new("verbose")
+                    .short('v')
+                    .long("verbose")
+                    .takes_value(false)
+                    .help("Show a detailed output"),
+            )
+            .arg(
+                Arg::new("recursive")
+                    .short('r')
+                    .long("recursive")
+                    .takes_value(false)
+                    .help("Index files and folders within other folders (index recursively)"),
+            )
+            .arg(
+                Arg::new("hidden")
+                    .long("hidden")
+                    .takes_value(false)
+                    .help("Include hidden files"),
+            )
+            .arg(
+                Arg::new("keyfile")
+                    .short('k')
+                    .long("keyfile")
+                    .value_name("file")
+                    .takes_value(true)
+                    .help("Use a keyfile instead of a password"),
+            )
+            .arg(
+                Arg::new("erase")
+                    .long("erase")
+                    .value_name("# of passes")
+                    .takes_value(true)
+                    .require_equals(true)
+                    .help("Securely erase the input file once complete (default is 2 passes)")
+                    .min_values(0)
+                    .default_missing_value("2"),
+            )
+            .arg(
+                Arg::new("hash")
+                    .short('H')
+                    .long("hash")
+                    .takes_value(false)
+                    .help("Return a BLAKE3 hash of the encrypted file"),
+            )
+            .arg(
+                Arg::new("skip")
+                    .short('y')
+                    .long("skip")
+                    .takes_value(false)
+                    .help("Skip all prompts"),
+            )
+            .arg(
+                Arg::new("password")
+                    .short('p')
+                    .long("password")
+                    .takes_value(false)
+                    .help("Interactively ask for your password")
+                    .conflicts_with("keyfile"),
+            )
+            .arg(
+                Arg::new("aead")
+                    .short('a')
+                    .long("aead")
+                    .value_name("aead to use for encryption")
+                    .takes_value(true)
+                    .help("select an AEAD (\"dexios list aead\" to see all possible values)"),
+            )
+        )
+        .subcommand(
             Command::new("header")
                 .about("Manipulate encrypted headers (for advanced users)")
                 .subcommand_required(true)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -207,6 +207,13 @@ pub fn get_matches() -> clap::ArgMatches {
                     .help("The output file"),
             )
             .arg(
+                Arg::new("delete")
+                    .short('d')
+                    .long("delete")
+                    .takes_value(false)
+                    .help("Delete the source directory once packed"),
+            )
+            .arg(
                 Arg::new("verbose")
                     .short('v')
                     .long("verbose")

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,6 +1,9 @@
 use anyhow::{Context, Ok, Result};
 use dexios_core::protected::Protected;
-use std::{fs::File, io::Read};
+use paris::Logger;
+use std::{fs::{File, read_dir}, io::Read, path::PathBuf};
+
+use crate::global::states::{DirectoryMode, HiddenFilesMode, PrintMode};
 
 // this takes the name/relative path of a file, and returns the bytes in a "protected" wrapper
 pub fn get_bytes(name: &str) -> Result<Protected<Vec<u8>>> {
@@ -9,4 +12,77 @@ pub fn get_bytes(name: &str) -> Result<Protected<Vec<u8>>> {
     file.read_to_end(&mut data)
         .with_context(|| format!("Unable to read file: {}", name))?;
     Ok(Protected::new(data))
+}
+
+// this indexes all files/folders within a specific path
+// it's used by pack mode
+// it can run recursively if DirectoryMode::Recursive is passed to it
+// it returns the files and directories that it finds
+pub fn get_paths_in_dir(
+    name: &str,
+    mode: DirectoryMode,
+    exclude: &[String],
+    hidden: &HiddenFilesMode,
+    print_mode: &PrintMode,
+) -> Result<(Vec<PathBuf>, Option<Vec<PathBuf>>)> {
+    let mut logger = Logger::new();
+    let mut file_list = Vec::new(); // so we know what files to encrypt
+    let mut dir_list = Vec::new(); // so we can recreate the structure inside of the zip file
+
+    let paths =
+        read_dir(name).with_context(|| format!("Unable to open the directory: {}", name))?;
+
+    'dirs: for item in paths {
+        let path = item
+            .with_context(|| format!("Unable to get the item's path: {}", name))?
+            .path(); // not great error message
+
+        let file_name = path
+            .file_name()
+            .context("Unable to get file name from path")?
+            .to_str()
+            .context("Unable to convert OsStr into str")?;
+        let first_char = file_name
+            .chars()
+            .next()
+            .context("Unable to get first character of the file/folder's name")?;
+
+        if hidden == &HiddenFilesMode::Exclude && first_char == '.' {
+            continue;
+        }
+
+        for pattern in exclude {
+            if file_name == *pattern {
+                continue 'dirs;
+            }
+        }
+
+        if path.is_dir() && mode == DirectoryMode::Recursive {
+            let (files, dirs) =
+                get_paths_in_dir(path.to_str().unwrap(), mode, exclude, hidden, print_mode)?;
+            dir_list.push(path);
+
+            file_list.extend(files);
+            dir_list.extend(dirs.unwrap()); // this should never error and it should be there, at least empty - should still add context
+        } else if path.is_dir() {
+            if print_mode == &PrintMode::Verbose {
+                logger.warn(format!(
+                    "Skipping {} as it's a directory and -r was not specified",
+                    path.display()
+                ));
+            }
+        } else if path.is_symlink() {
+            if print_mode == &PrintMode::Verbose {
+                logger.warn(format!("Skipping {} as it's a symlink", path.display()));
+            }
+        } else {
+            file_list.push(path);
+        }
+    }
+
+    if mode == DirectoryMode::Recursive {
+        Ok((file_list, Some(dir_list)))
+    } else {
+        Ok((file_list, None))
+    }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,7 +1,11 @@
 use anyhow::{Context, Ok, Result};
 use dexios_core::protected::Protected;
 use paris::Logger;
-use std::{fs::{File, read_dir}, io::Read, path::PathBuf};
+use std::{
+    fs::{read_dir, File},
+    io::Read,
+    path::PathBuf,
+};
 
 use crate::global::states::{DirectoryMode, HiddenFilesMode, PrintMode};
 

--- a/src/global/parameters.rs
+++ b/src/global/parameters.rs
@@ -207,8 +207,8 @@ pub fn pack_params(sub_matches: &ArgMatches) -> Result<(CryptoParams, PackParams
 
     let pack_params = PackParams {
         dir_mode,
-        exclude,
         hidden,
+        exclude,
         print_mode,
     };
 

--- a/src/global/parameters.rs
+++ b/src/global/parameters.rs
@@ -3,12 +3,15 @@
 
 use crate::global::states::{EraseMode, HashMode, HeaderFile, KeyFile, PasswordMode, SkipMode};
 use crate::global::structs::CryptoParams;
+use crate::global::structs::PackParams;
 use anyhow::{Context, Result};
 use clap::ArgMatches;
 use dexios_core::primitives::Algorithm;
 use paris::warn;
 
 use dexios_core::primitives::ALGORITHMS;
+
+use super::states::{PrintMode, DirectoryMode, HiddenFilesMode};
 
 pub fn get_param(name: &str, sub_matches: &ArgMatches) -> Result<String> {
     let value = sub_matches
@@ -129,6 +132,84 @@ pub fn erase_params(sub_matches: &ArgMatches) -> Result<i32> {
     };
 
     Ok(passes)
+}
+
+pub fn pack_params(sub_matches: &ArgMatches) -> Result<(CryptoParams, PackParams)> {
+    let keyfile = if sub_matches.is_present("keyfile") {
+        KeyFile::Some(
+            sub_matches
+                .value_of("keyfile")
+                .context("No keyfile/invalid text provided")?
+                .to_string(),
+        )
+    } else {
+        KeyFile::None
+    };
+
+    let hash_mode = if sub_matches.is_present("hash") {
+        //specify to emit hash after operation
+        HashMode::CalculateHash
+    } else {
+        // default
+        HashMode::NoHash
+    };
+
+    let skip = skipmode(sub_matches);
+
+    let erase = EraseMode::IgnoreFile(0);
+
+    let password = if sub_matches.is_present("password") {
+        //Overwrite, so the user provided password is used and ignore environment supplied one?!
+        PasswordMode::ForceUserProvidedPassword
+    } else {
+        // default
+        PasswordMode::NormalKeySourcePriority
+    };
+
+    let crypto_params = CryptoParams {
+        hash_mode,
+        skip,
+        password,
+        erase,
+        keyfile,
+    };
+
+    let print_mode = if sub_matches.is_present("verbose") {
+        //specify to emit hash after operation
+        PrintMode::Verbose
+    } else {
+        // default
+        PrintMode::Quiet
+    };
+
+    let dir_mode = if sub_matches.is_present("recursive") {
+        //specify to emit hash after operation
+        DirectoryMode::Recursive
+    } else {
+        // default
+        DirectoryMode::Singular
+    };
+
+    let hidden = if sub_matches.is_present("hidden") {
+        //specify to emit hash after operation
+        HiddenFilesMode::Include
+    } else {
+        // default
+        HiddenFilesMode::Exclude
+    };
+
+    let exclude: Vec<String> = if sub_matches.is_present("exclude") {
+        let list: Vec<&str> = sub_matches.values_of("exclude").unwrap().collect();
+        list.iter().map(std::string::ToString::to_string).collect()
+    } else {
+        Vec::new()
+    };
+
+
+
+    let pack_params = PackParams { dir_mode, exclude, hidden, print_mode, };
+
+    Ok((crypto_params, pack_params))
 }
 
 pub fn skipmode(sub_matches: &ArgMatches) -> SkipMode {

--- a/src/global/parameters.rs
+++ b/src/global/parameters.rs
@@ -1,7 +1,9 @@
 // this file handles getting parameters from clap's ArgMatches
 // it returns information (e.g. CryptoParams) to functions that require it
 
-use crate::global::states::{EraseMode, HashMode, HeaderFile, KeyFile, PasswordMode, SkipMode, DeleteSourceDir};
+use crate::global::states::{
+    DeleteSourceDir, EraseMode, HashMode, HeaderFile, KeyFile, PasswordMode, SkipMode,
+};
 use crate::global::structs::CryptoParams;
 use crate::global::structs::PackParams;
 use anyhow::{Context, Result};

--- a/src/global/parameters.rs
+++ b/src/global/parameters.rs
@@ -11,7 +11,7 @@ use paris::warn;
 
 use dexios_core::primitives::ALGORITHMS;
 
-use super::states::{PrintMode, DirectoryMode, HiddenFilesMode};
+use super::states::{DirectoryMode, HiddenFilesMode, PrintMode};
 
 pub fn get_param(name: &str, sub_matches: &ArgMatches) -> Result<String> {
     let value = sub_matches
@@ -205,9 +205,12 @@ pub fn pack_params(sub_matches: &ArgMatches) -> Result<(CryptoParams, PackParams
         Vec::new()
     };
 
-
-
-    let pack_params = PackParams { dir_mode, exclude, hidden, print_mode, };
+    let pack_params = PackParams {
+        dir_mode,
+        exclude,
+        hidden,
+        print_mode,
+    };
 
     Ok((crypto_params, pack_params))
 }

--- a/src/global/parameters.rs
+++ b/src/global/parameters.rs
@@ -1,7 +1,7 @@
 // this file handles getting parameters from clap's ArgMatches
 // it returns information (e.g. CryptoParams) to functions that require it
 
-use crate::global::states::{EraseMode, HashMode, HeaderFile, KeyFile, PasswordMode, SkipMode};
+use crate::global::states::{EraseMode, HashMode, HeaderFile, KeyFile, PasswordMode, SkipMode, DeleteSourceDir};
 use crate::global::structs::CryptoParams;
 use crate::global::structs::PackParams;
 use anyhow::{Context, Result};
@@ -205,11 +205,18 @@ pub fn pack_params(sub_matches: &ArgMatches) -> Result<(CryptoParams, PackParams
         Vec::new()
     };
 
+    let delete_source = if sub_matches.is_present("delete") {
+        DeleteSourceDir::Delete
+    } else {
+        DeleteSourceDir::Retain
+    };
+
     let pack_params = PackParams {
         dir_mode,
         hidden,
         exclude,
         print_mode,
+        delete_source,
     };
 
     Ok((crypto_params, pack_params))

--- a/src/global/states.rs
+++ b/src/global/states.rs
@@ -18,6 +18,12 @@ pub enum HiddenFilesMode {
 }
 
 #[derive(PartialEq)]
+pub enum DeleteSourceDir {
+    Delete,
+    Retain,
+}
+
+#[derive(PartialEq)]
 pub enum PrintMode {
     Verbose,
     Quiet,

--- a/src/global/states.rs
+++ b/src/global/states.rs
@@ -5,6 +5,24 @@
 
 use anyhow::Result;
 
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum DirectoryMode {
+    Singular,
+    Recursive,
+}
+
+#[derive(PartialEq)]
+pub enum HiddenFilesMode {
+    Include,
+    Exclude,
+}
+
+#[derive(PartialEq)]
+pub enum PrintMode {
+    Verbose,
+    Quiet,
+}
+
 #[derive(PartialEq, Clone, Copy)]
 pub enum EraseMode {
     EraseFile(i32),

--- a/src/global/structs.rs
+++ b/src/global/structs.rs
@@ -1,6 +1,6 @@
 use crate::global::states::{HashMode, KeyFile, PasswordMode, SkipMode};
 
-use super::states::{EraseMode, DirectoryMode, HiddenFilesMode, PrintMode};
+use super::states::{DirectoryMode, EraseMode, HiddenFilesMode, PrintMode};
 
 pub struct CryptoParams {
     pub hash_mode: HashMode,

--- a/src/global/structs.rs
+++ b/src/global/structs.rs
@@ -10,7 +10,7 @@ pub struct CryptoParams {
     pub keyfile: KeyFile,
 }
 
-pub struct PackMode {
+pub struct PackParams {
     pub dir_mode: DirectoryMode,
     pub hidden: HiddenFilesMode,
     pub exclude: Vec<String>,

--- a/src/global/structs.rs
+++ b/src/global/structs.rs
@@ -1,6 +1,6 @@
 use crate::global::states::{HashMode, KeyFile, PasswordMode, SkipMode};
 
-use super::states::{DirectoryMode, EraseMode, HiddenFilesMode, PrintMode, DeleteSourceDir};
+use super::states::{DeleteSourceDir, DirectoryMode, EraseMode, HiddenFilesMode, PrintMode};
 
 pub struct CryptoParams {
     pub hash_mode: HashMode,

--- a/src/global/structs.rs
+++ b/src/global/structs.rs
@@ -1,6 +1,6 @@
 use crate::global::states::{HashMode, KeyFile, PasswordMode, SkipMode};
 
-use super::states::{DirectoryMode, EraseMode, HiddenFilesMode, PrintMode};
+use super::states::{DirectoryMode, EraseMode, HiddenFilesMode, PrintMode, DeleteSourceDir};
 
 pub struct CryptoParams {
     pub hash_mode: HashMode,
@@ -15,4 +15,5 @@ pub struct PackParams {
     pub hidden: HiddenFilesMode,
     pub exclude: Vec<String>,
     pub print_mode: PrintMode,
+    pub delete_source: DeleteSourceDir,
 }

--- a/src/global/structs.rs
+++ b/src/global/structs.rs
@@ -1,6 +1,6 @@
 use crate::global::states::{HashMode, KeyFile, PasswordMode, SkipMode};
 
-use super::states::EraseMode;
+use super::states::{EraseMode, DirectoryMode, HiddenFilesMode, PrintMode};
 
 pub struct CryptoParams {
     pub hash_mode: HashMode,
@@ -8,4 +8,11 @@ pub struct CryptoParams {
     pub password: PasswordMode,
     pub erase: EraseMode,
     pub keyfile: KeyFile,
+}
+
+pub struct PackMode {
+    pub dir_mode: DirectoryMode,
+    pub hidden: HiddenFilesMode,
+    pub exclude: Vec<String>,
+    pub print_mode: PrintMode,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,9 @@ fn main() -> Result<()> {
         Some(("erase", sub_matches)) => {
             subcommands::erase(sub_matches)?;
         }
+        Some(("pack", sub_matches)) => {
+            subcommands::pack(sub_matches)?;
+        }
         Some(("hash", sub_matches)) => {
             let files: Vec<String> = if sub_matches.is_present("input") {
                 let list: Vec<&str> = sub_matches.values_of("input").unwrap().collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,9 @@ fn main() -> Result<()> {
         Some(("pack", sub_matches)) => {
             subcommands::pack(sub_matches)?;
         }
+        Some(("unpack", sub_matches)) => {
+            subcommands::unpack(sub_matches)?;
+        }
         Some(("hash", sub_matches)) => {
             let files: Vec<String> = if sub_matches.is_present("input") {
                 let list: Vec<&str> = sub_matches.values_of("input").unwrap().collect();

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -55,18 +55,12 @@ pub fn erase(sub_matches: &ArgMatches) -> Result<()> {
 pub fn pack(sub_matches: &ArgMatches) -> Result<()> {
     let (crypto_params, pack_params) = pack_params(sub_matches)?;
     let aead = encrypt_additional_params(sub_matches)?;
-    let delete_source = if sub_matches.is_present("delete") {
-        DeleteSourceDir::Delete
-    } else {
-        DeleteSourceDir::Retain
-    };
 
     pack::pack(
         &get_param("input", sub_matches)?,
         &get_param("output", sub_matches)?,
         &pack_params,
         &crypto_params,
-        &delete_source,
         aead,
     )
 }

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -4,10 +4,10 @@ use clap::ArgMatches;
 // this is called from main.rs
 // it gets params and sends them to the appropriate functions
 
-use crate::global::parameters::{
+use crate::global::{parameters::{
     decrypt_additional_params, encrypt_additional_params, erase_params, get_param, pack_params,
     parameter_handler,
-};
+}, states::DeleteSourceDir};
 
 pub mod decrypt;
 pub mod encrypt;
@@ -55,11 +55,18 @@ pub fn erase(sub_matches: &ArgMatches) -> Result<()> {
 pub fn pack(sub_matches: &ArgMatches) -> Result<()> {
     let (crypto_params, pack_params) = pack_params(sub_matches)?;
     let aead = encrypt_additional_params(sub_matches)?;
+    let delete_source = if sub_matches.is_present("delete") {
+        DeleteSourceDir::Delete
+    } else {
+        DeleteSourceDir::Retain
+    };
+
     pack::pack(
         &get_param("input", sub_matches)?,
         &get_param("output", sub_matches)?,
         &pack_params,
         &crypto_params,
+        &delete_source,
         aead,
     )
 }

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -5,8 +5,8 @@ use clap::ArgMatches;
 // it gets params and sends them to the appropriate functions
 
 use crate::global::parameters::{
-    decrypt_additional_params, encrypt_additional_params, erase_params, get_param,
-    parameter_handler, pack_params,
+    decrypt_additional_params, encrypt_additional_params, erase_params, get_param, pack_params,
+    parameter_handler,
 };
 
 pub mod decrypt;
@@ -16,8 +16,8 @@ pub mod hashing;
 pub mod header;
 pub mod key;
 pub mod list;
-pub mod prompt;
 pub mod pack;
+pub mod prompt;
 pub mod unpack;
 
 pub fn encrypt(sub_matches: &ArgMatches) -> Result<()> {
@@ -55,7 +55,13 @@ pub fn erase(sub_matches: &ArgMatches) -> Result<()> {
 pub fn pack(sub_matches: &ArgMatches) -> Result<()> {
     let (crypto_params, pack_params) = pack_params(sub_matches)?;
     let aead = encrypt_additional_params(sub_matches)?;
-    pack::pack(&get_param("input", sub_matches)?, &get_param("output", sub_matches)?, &pack_params, &crypto_params, aead)
+    pack::pack(
+        &get_param("input", sub_matches)?,
+        &get_param("output", sub_matches)?,
+        &pack_params,
+        &crypto_params,
+        aead,
+    )
 }
 
 pub fn unpack(sub_matches: &ArgMatches) -> Result<()> {
@@ -72,5 +78,11 @@ pub fn unpack(sub_matches: &ArgMatches) -> Result<()> {
         PrintMode::Quiet
     };
 
-    unpack::unpack(&get_param("input", sub_matches)?, &get_param("output", sub_matches)?, &header, &print_mode, &crypto_params)
+    unpack::unpack(
+        &get_param("input", sub_matches)?,
+        &get_param("output", sub_matches)?,
+        &header,
+        &print_mode,
+        &crypto_params,
+    )
 }

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -57,3 +57,20 @@ pub fn pack(sub_matches: &ArgMatches) -> Result<()> {
     let aead = encrypt_additional_params(sub_matches)?;
     pack::pack(&get_param("input", sub_matches)?, &get_param("output", sub_matches)?, &pack_params, &crypto_params, aead)
 }
+
+pub fn unpack(sub_matches: &ArgMatches) -> Result<()> {
+    use super::global::states::PrintMode;
+
+    let crypto_params = parameter_handler(sub_matches)?;
+    let header = decrypt_additional_params(sub_matches)?;
+
+    let print_mode = if sub_matches.is_present("verbose") {
+        //specify to emit hash after operation
+        PrintMode::Verbose
+    } else {
+        // default
+        PrintMode::Quiet
+    };
+
+    unpack::unpack(&get_param("input", sub_matches)?, &get_param("output", sub_matches)?, &header, &print_mode, &crypto_params)
+}

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -4,10 +4,10 @@ use clap::ArgMatches;
 // this is called from main.rs
 // it gets params and sends them to the appropriate functions
 
-use crate::global::{parameters::{
+use crate::global::parameters::{
     decrypt_additional_params, encrypt_additional_params, erase_params, get_param, pack_params,
     parameter_handler,
-}, states::DeleteSourceDir};
+};
 
 pub mod decrypt;
 pub mod encrypt;

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -17,6 +17,8 @@ pub mod header;
 pub mod key;
 pub mod list;
 pub mod prompt;
+pub mod pack;
+pub mod unpack;
 
 pub fn encrypt(sub_matches: &ArgMatches) -> Result<()> {
     let params = parameter_handler(sub_matches)?;

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -6,7 +6,7 @@ use clap::ArgMatches;
 
 use crate::global::parameters::{
     decrypt_additional_params, encrypt_additional_params, erase_params, get_param,
-    parameter_handler,
+    parameter_handler, pack_params,
 };
 
 pub mod decrypt;
@@ -50,4 +50,10 @@ pub fn erase(sub_matches: &ArgMatches) -> Result<()> {
     let passes = erase_params(sub_matches)?;
 
     erase::secure_erase(&get_param("input", sub_matches)?, passes)
+}
+
+pub fn pack(sub_matches: &ArgMatches) -> Result<()> {
+    let (crypto_params, pack_params) = pack_params(sub_matches)?;
+    let aead = encrypt_additional_params(sub_matches)?;
+    pack::pack(&get_param("input", sub_matches)?, &get_param("output", sub_matches)?, &pack_params, &crypto_params, aead)
 }

--- a/src/subcommands/pack.rs
+++ b/src/subcommands/pack.rs
@@ -28,7 +28,6 @@ pub fn pack(
     output: &str,
     pack_params: &PackParams,
     params: &CryptoParams,
-    delete_source: &DeleteSourceDir,
     algorithm: Algorithm,
 ) -> Result<()> {
     let mut logger = Logger::new();
@@ -141,6 +140,10 @@ pub fn pack(
     super::encrypt::stream_mode(&tmp_name, output, params, algorithm)?;
 
     super::erase::secure_erase(&tmp_name, 2)?; // cleanup our tmp file
+
+    if pack_params.delete_source == DeleteSourceDir::Delete {
+        std::fs::remove_dir_all(input).context("Unable to delete source directory")?;
+    }
 
     logger.success(format!("Your output file is: {}", output));
 

--- a/src/subcommands/pack.rs
+++ b/src/subcommands/pack.rs
@@ -1,0 +1,149 @@
+use std::{
+    fs::File,
+    io::{Read, Write},
+    time::Instant,
+};
+
+use anyhow::{Context, Result};
+use dexios_core::primitives::{Algorithm, BLOCK_SIZE};
+use paris::Logger;
+use rand::distributions::{Alphanumeric, DistString};
+use zip::write::FileOptions;
+
+use crate::{
+    file::get_paths_in_dir,
+    global::states::{DirectoryMode, PrintMode},
+    global::structs::{CryptoParams, PackMode},
+};
+
+// this first indexes the input directory
+// once it has the total number of files/folders, it creates a temporary zip file
+// it compresses all of the files into the temporary archive
+// once compressed, it encrypts the zip file
+// it erases the temporary archive afterwards, to stop any residual data from remaining
+#[allow(clippy::module_name_repetitions)]
+#[allow(clippy::too_many_lines)]
+pub fn pack(
+    input: &str,
+    output: &str,
+    pack_params: &PackMode,
+    params: &CryptoParams,
+    algorithm: Algorithm,
+) -> Result<()> {
+    let mut logger = Logger::new();
+
+    if pack_params.dir_mode == DirectoryMode::Recursive {
+        logger.info(format!("Traversing {} recursively", input));
+    } else {
+        logger.info(format!("Traversing {}", input));
+    }
+
+    let index_start_time = Instant::now();
+    let (files, dirs) = get_paths_in_dir(
+        input,
+        pack_params.dir_mode,
+        &pack_params.exclude,
+        &pack_params.hidden,
+        &pack_params.print_mode,
+    )?;
+    let index_duration = index_start_time.elapsed();
+    let file_count = files.len();
+    logger.success(format!(
+        "Indexed {} files [took {:.2}s]",
+        file_count,
+        index_duration.as_secs_f32()
+    ));
+
+    let random_extension: String = Alphanumeric.sample_string(&mut rand::thread_rng(), 8);
+    let tmp_name = format!("{}.{}", output, random_extension); // e.g. "output.kjHSD93l"
+
+    let file = std::io::BufWriter::new(
+        File::create(&tmp_name)
+            .with_context(|| format!("Unable to create the output file: {}", output))?,
+    );
+
+    logger.info(format!("Creating and compressing files into {}", tmp_name));
+
+    let zip_start_time = Instant::now();
+
+    let mut zip = zip::ZipWriter::new(file);
+    let options = FileOptions::default()
+        .compression_method(zip::CompressionMethod::Stored)
+        .large_file(true)
+        .unix_permissions(0o755);
+
+    zip.add_directory(input, options)
+        .context("Unable to add directory to zip")?;
+
+    if pack_params.dir_mode == DirectoryMode::Recursive {
+        let directories = dirs.context("Error unwrapping Vec containing list of directories.")?; // this should always be *something* anyway
+        for dir in directories {
+            zip.add_directory(
+                dir.to_str()
+                    .context("Error converting directory path to string")?,
+                options,
+            )
+            .context("Unable to add directory to zip")?;
+        }
+    }
+
+    for file in files {
+        zip.start_file(
+            file.to_str()
+                .context("Error converting file path to string")?,
+            options,
+        )
+        .context("Unable to add file to zip")?;
+
+        if pack_params.print_mode == PrintMode::Verbose {
+            logger.info(format!(
+                "Compressing {} into {}",
+                file.to_str().unwrap(),
+                tmp_name
+            ));
+        }
+
+        let zip_writer = zip.by_ref();
+        let mut file_reader = File::open(file)?;
+        let file_size = file_reader.metadata().unwrap().len();
+
+        if file_size <= BLOCK_SIZE.try_into().unwrap() {
+            let mut data = Vec::new();
+            file_reader.read_to_end(&mut data)?;
+            zip_writer.write_all(&data)?;
+        } else {
+            // stream read/write here
+            let mut buffer = vec![0u8; BLOCK_SIZE].into_boxed_slice();
+
+            loop {
+                let read_count = file_reader.read(&mut buffer)?;
+                zip_writer
+                    .write_all(&buffer[..read_count])
+                    .with_context(|| {
+                        format!("Unable to write to the output file: {}", output)
+                    })?;
+                if read_count != BLOCK_SIZE {
+                    break;
+                }
+            }
+        }
+    }
+    zip.finish()?;
+    drop(zip);
+
+    let zip_duration = zip_start_time.elapsed();
+    logger.success(format!(
+        "Compressed {} files into {}! [took {:.2}s]",
+        file_count,
+        tmp_name,
+        zip_duration.as_secs_f32()
+    ));
+
+    super::encrypt::stream_mode(&tmp_name, output, params, algorithm)?;
+
+    super::erase::secure_erase(&tmp_name, 2)?; // cleanup our tmp file
+
+    logger.success(format!("Your output file is: {}", output));
+
+    Ok(())
+}

--- a/src/subcommands/pack.rs
+++ b/src/subcommands/pack.rs
@@ -13,7 +13,7 @@ use zip::write::FileOptions;
 use crate::{
     file::get_paths_in_dir,
     global::states::{DirectoryMode, PrintMode},
-    global::structs::{CryptoParams, PackMode},
+    global::structs::{CryptoParams, PackParams},
 };
 
 // this first indexes the input directory
@@ -26,7 +26,7 @@ use crate::{
 pub fn pack(
     input: &str,
     output: &str,
-    pack_params: &PackMode,
+    pack_params: &PackParams,
     params: &CryptoParams,
     algorithm: Algorithm,
 ) -> Result<()> {

--- a/src/subcommands/pack.rs
+++ b/src/subcommands/pack.rs
@@ -12,7 +12,7 @@ use zip::write::FileOptions;
 
 use crate::{
     file::get_paths_in_dir,
-    global::states::{DirectoryMode, PrintMode},
+    global::states::{DirectoryMode, PrintMode, DeleteSourceDir},
     global::structs::{CryptoParams, PackParams},
 };
 
@@ -28,6 +28,7 @@ pub fn pack(
     output: &str,
     pack_params: &PackParams,
     params: &CryptoParams,
+    delete_source: &DeleteSourceDir,
     algorithm: Algorithm,
 ) -> Result<()> {
     let mut logger = Logger::new();

--- a/src/subcommands/pack.rs
+++ b/src/subcommands/pack.rs
@@ -119,9 +119,7 @@ pub fn pack(
                 let read_count = file_reader.read(&mut buffer)?;
                 zip_writer
                     .write_all(&buffer[..read_count])
-                    .with_context(|| {
-                        format!("Unable to write to the output file: {}", output)
-                    })?;
+                    .with_context(|| format!("Unable to write to the output file: {}", output))?;
                 if read_count != BLOCK_SIZE {
                     break;
                 }

--- a/src/subcommands/pack.rs
+++ b/src/subcommands/pack.rs
@@ -12,7 +12,7 @@ use zip::write::FileOptions;
 
 use crate::{
     file::get_paths_in_dir,
-    global::states::{DirectoryMode, PrintMode, DeleteSourceDir},
+    global::states::{DeleteSourceDir, DirectoryMode, PrintMode},
     global::structs::{CryptoParams, PackParams},
 };
 

--- a/src/subcommands/unpack.rs
+++ b/src/subcommands/unpack.rs
@@ -38,7 +38,7 @@ pub fn unpack(
 
     match std::fs::create_dir(output) {
         Ok(_) => logger.info(format!("Created output directory: {}", output)),
-        Err(_) => logger.warn(format!("Output directory ({}) already exists!", output)),
+        Err(_) => logger.info(format!("Output directory ({}) already exists", output)),
     };
 
     let file_count = archive.len();

--- a/src/subcommands/unpack.rs
+++ b/src/subcommands/unpack.rs
@@ -1,0 +1,112 @@
+use anyhow::{Result, Context};
+use rand::distributions::{Alphanumeric, DistString};
+
+use crate::global::{states::{HeaderFile, PrintMode, SkipMode}, structs::CryptoParams};
+use paris::Logger;
+use std::{time::Instant, str::FromStr};
+use std::fs::File;
+use std::path::PathBuf;
+
+use super::prompt::get_answer;
+
+// this first decrypts the input file to a temporary zip file
+// it then unpacks that temporary zip file to the target directory
+// once finished, it erases the temporary file to avoid any residual data
+#[allow(clippy::module_name_repetitions)]
+pub fn unpack(
+    input: &str,         // encrypted zip file
+    output: &str,        // directory
+    header: &HeaderFile, // for decrypt function
+    print_mode: &PrintMode,
+    params: &CryptoParams, // params for decrypt function
+) -> Result<()> {
+    let mut logger = Logger::new();
+    let random_extension: String = Alphanumeric.sample_string(&mut rand::thread_rng(), 8);
+
+    // this is the name of the decrypted zip file
+    let tmp_name = format!("{}.{}", input, random_extension); // e.g. "input.kjHSD93l"
+
+    super::decrypt::stream_mode(input, &tmp_name, header, params)?;
+
+    let zip_start_time = Instant::now();
+    let file = File::open(&tmp_name).context("Unable to open temporary archive")?;
+    let mut archive = zip::ZipArchive::new(file)
+        .context("Temporary archive can't be opened, is it a zip file?")?;
+
+    match std::fs::create_dir(output) {
+        Ok(_) => logger.info(format!("Created output directory: {}", output)),
+        Err(_) => logger.warn(format!("Output directory ({}) already exists!", output)),
+    };
+
+    let file_count = archive.len();
+
+    logger.info(format!(
+        "Decompressing {} items into {}",
+        file_count, output
+    ));
+
+    for i in 0..file_count {
+        let mut full_path = PathBuf::from_str(output)
+            .context("Unable to create a PathBuf from your output directory")?;
+
+        let mut file = archive.by_index(i).context("Unable to index the archive")?;
+        match file.enclosed_name() {
+            Some(path) => full_path.push(path),
+            None => continue,
+        };
+
+        if file.name().contains("..") {
+            // skip directories that may try to zip slip
+            continue;
+        }
+
+        if file.is_dir() {
+            // if it's a directory, recreate the structure
+            std::fs::create_dir_all(full_path).context("Unable to create an output directory")?;
+        } else {
+            // this must be a file
+            let file_name: String = full_path
+                .clone()
+                .file_name()
+                .context("Unable to convert file name to OsStr")?
+                .to_str()
+                .context("Unable to convert file name's OsStr to &str")?
+                .to_string();
+            if std::fs::metadata(full_path.clone()).is_ok() {
+                let answer = get_answer(
+                    &format!("{} already exists, would you like to overwrite?", file_name),
+                    true,
+                    params.skip == SkipMode::HidePrompts,
+                )?;
+                if !answer {
+                    logger.warn(format!("Skipping {}", file_name));
+                    continue;
+                }
+            }
+            if print_mode == &PrintMode::Verbose {
+                logger.info(format!("Extracting {}", file_name));
+            }
+            let mut output_file =
+                File::create(full_path).context("Error creating an output file")?;
+            std::io::copy(&mut file, &mut output_file)
+                .context("Error copying data out of archive to the target file")?;
+        }
+    }
+
+    let zip_duration = zip_start_time.elapsed();
+    logger.success(format!(
+        "Extracted {} items to {} [took {:.2}s]",
+        file_count,
+        output,
+        zip_duration.as_secs_f32()
+    ));
+
+    super::erase::secure_erase(&tmp_name, 2)?; // cleanup the tmp file
+
+    logger.success(format!(
+        "Unpacking Successful! You will find your files in {}",
+        output
+    ));
+
+    Ok(())
+}

--- a/src/subcommands/unpack.rs
+++ b/src/subcommands/unpack.rs
@@ -1,11 +1,14 @@
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use rand::distributions::{Alphanumeric, DistString};
 
-use crate::global::{states::{HeaderFile, PrintMode, SkipMode}, structs::CryptoParams};
+use crate::global::{
+    states::{HeaderFile, PrintMode, SkipMode},
+    structs::CryptoParams,
+};
 use paris::Logger;
-use std::{time::Instant, str::FromStr};
 use std::fs::File;
 use std::path::PathBuf;
+use std::{str::FromStr, time::Instant};
 
 use super::prompt::get_answer;
 

--- a/src/subcommands/unpack.rs
+++ b/src/subcommands/unpack.rs
@@ -55,8 +55,13 @@ pub fn unpack(
             None => continue,
         };
 
+        // zip slip prevention
         if file.name().contains("..") {
-            // skip directories that may try to zip slip
+            continue;
+        }
+
+        #[cfg(windows)] // zip slip prevention
+        if file.name().contains(".\\") {
             continue;
         }
 


### PR DESCRIPTION
This branch adds a revamped pack/unpack mode.

There are more zip-slip protections, and the syntax has been improved dramatically.

`dexios pack directory/ file.enc` and `dexios unpack file.enc .` can be used for seamless packing/encrypting, and unpacking/decrypting.