### PR TITLE
fix annoying zip/windows issue

### DIFF
--- a/src/subcommands/pack.rs
+++ b/src/subcommands/pack.rs
@@ -70,10 +70,6 @@ pub fn pack(
         let item_data = item.context("Unable to get path of item, skipping")?;
         let item = item_data.path();
 
-        #[cfg(unix)]
-        let item_str = item.to_str().context("Error converting directory path to string")?;
-
-        #[cfg(windows)]
         let item_str = item.to_str().context("Error converting directory path to string")?.replace(r"\", "/");
 
         if item.is_dir() {

--- a/src/subcommands/pack.rs
+++ b/src/subcommands/pack.rs
@@ -70,10 +70,15 @@ pub fn pack(
         let item_data = item.context("Unable to get path of item, skipping")?;
         let item = item_data.path();
 
+        #[cfg(unix)]
+        let item_str = item.to_str().context("Error converting directory path to string")?;
+
+        #[cfg(windows)]
+        let item_str = item.to_str().context("Error converting directory path to string")?.replace(r"\", "/");
+
         if item.is_dir() {
             zip.add_directory(
-                item.to_str()
-                    .context("Error converting directory path to string")?,
+                item_str,
                 options,
             )
             .context("Unable to add directory to zip")?;
@@ -82,8 +87,7 @@ pub fn pack(
         }
 
         zip.start_file(
-            item.to_str()
-                .context("Error converting file path to string")?,
+            item_str,
             options,
         )
         .context("Unable to add file to zip")?;


### PR DESCRIPTION
This fixes the issue mentioned in #50 - it's very annoying and was hard to debug.

The `zip` crate was treating `\` as a random character, and it was causing everything to be messed up.

It was a rather simple fix, but if the running OS is Windows, replace all `\` characters in the path with `/`.

I'm going to test the `unpack` functionality further, but I believe this issue should be fixed.