### PR TITLE
Compression support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -387,6 +390,15 @@ checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -646,4 +658,34 @@ dependencies = [
  "byteorder",
  "crc32fast",
  "crossbeam-utils",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.10.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "4.1.6+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.6.3+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ clap = { version = "3.1.18", features = ["cargo"] }
 anyhow = "1.0.57"
 paris = { version = "1.5.13", features = ["macros"] }
 
-zip = { version = "0.6.2", default-features = false }
+zip = { version = "0.6.2", default-features = false, features = ["zstd"] }
 
 [target.'cfg(unix)'.dependencies]
 termion = "1.5.6"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -220,6 +220,13 @@ pub fn get_matches() -> clap::ArgMatches {
                     .help("Show a detailed output"),
             )
             .arg(
+                Arg::new("zstd")
+                    .short('z')
+                    .long("zstd")
+                    .takes_value(false)
+                    .help("Use ZSTD compression"),
+            )
+            .arg(
                 Arg::new("recursive")
                     .short('r')
                     .long("recursive")

--- a/src/global/parameters.rs
+++ b/src/global/parameters.rs
@@ -13,7 +13,7 @@ use paris::warn;
 
 use dexios_core::primitives::ALGORITHMS;
 
-use super::states::{DirectoryMode, PrintMode, Compression};
+use super::states::{Compression, DirectoryMode, PrintMode};
 
 pub fn get_param(name: &str, sub_matches: &ArgMatches) -> Result<String> {
     let value = sub_matches
@@ -208,7 +208,7 @@ pub fn pack_params(sub_matches: &ArgMatches) -> Result<(CryptoParams, PackParams
         dir_mode,
         print_mode,
         erase_source,
-        compression
+        compression,
     };
 
     Ok((crypto_params, pack_params))

--- a/src/global/parameters.rs
+++ b/src/global/parameters.rs
@@ -13,7 +13,7 @@ use paris::warn;
 
 use dexios_core::primitives::ALGORITHMS;
 
-use super::states::{DirectoryMode, PrintMode};
+use super::states::{DirectoryMode, PrintMode, Compression};
 
 pub fn get_param(name: &str, sub_matches: &ArgMatches) -> Result<String> {
     let value = sub_matches
@@ -198,10 +198,17 @@ pub fn pack_params(sub_matches: &ArgMatches) -> Result<(CryptoParams, PackParams
         EraseSourceDir::Retain
     };
 
+    let compression = if sub_matches.is_present("zstd") {
+        Compression::Zstd
+    } else {
+        Compression::None
+    };
+
     let pack_params = PackParams {
         dir_mode,
         print_mode,
         erase_source,
+        compression
     };
 
     Ok((crypto_params, pack_params))

--- a/src/global/states.rs
+++ b/src/global/states.rs
@@ -11,6 +11,11 @@ pub enum DirectoryMode {
     Recursive,
 }
 
+pub enum Compression {
+    None,
+    Zstd,
+}
+
 #[derive(PartialEq)]
 pub enum HiddenFilesMode {
     Include,

--- a/src/global/structs.rs
+++ b/src/global/structs.rs
@@ -1,6 +1,6 @@
 use crate::global::states::{HashMode, KeyFile, PasswordMode, SkipMode};
 
-use super::states::{DirectoryMode, EraseMode, EraseSourceDir, PrintMode};
+use super::states::{DirectoryMode, EraseMode, EraseSourceDir, PrintMode, Compression};
 
 pub struct CryptoParams {
     pub hash_mode: HashMode,
@@ -14,4 +14,5 @@ pub struct PackParams {
     pub dir_mode: DirectoryMode,
     pub print_mode: PrintMode,
     pub erase_source: EraseSourceDir,
+    pub compression: Compression,
 }

--- a/src/global/structs.rs
+++ b/src/global/structs.rs
@@ -1,6 +1,6 @@
 use crate::global::states::{HashMode, KeyFile, PasswordMode, SkipMode};
 
-use super::states::{DirectoryMode, EraseMode, EraseSourceDir, PrintMode, Compression};
+use super::states::{Compression, DirectoryMode, EraseMode, EraseSourceDir, PrintMode};
 
 pub struct CryptoParams {
     pub hash_mode: HashMode,

--- a/src/subcommands/decrypt.rs
+++ b/src/subcommands/decrypt.rs
@@ -5,13 +5,13 @@ use crate::global::states::HashMode;
 use crate::global::states::HeaderFile;
 use crate::global::structs::CryptoParams;
 use anyhow::{Context, Result};
-use dexios_core::Zeroize;
 use dexios_core::header;
 use dexios_core::header::HeaderVersion;
 use dexios_core::key::argon2id_hash;
 use dexios_core::key::balloon_hash;
 use dexios_core::primitives::Mode;
 use dexios_core::protected::Protected;
+use dexios_core::Zeroize;
 use paris::Logger;
 
 use anyhow::anyhow;
@@ -209,10 +209,13 @@ pub fn stream_mode(
             );
             let cipher = Ciphers::initialize(key, &header.header_type.algorithm)?;
 
-            let master_key_result = cipher.decrypt(&header.master_key_nonce.unwrap(), header.master_key_encrypted.unwrap().as_slice());
+            let master_key_result = cipher.decrypt(
+                &header.master_key_nonce.unwrap(),
+                header.master_key_encrypted.unwrap().as_slice(),
+            );
             let mut master_key_decrypted = match master_key_result {
                 std::result::Result::Ok(bytes) => bytes,
-                Err(_) => return Err(anyhow::anyhow!("Unable to decrypt your master key"))
+                Err(_) => return Err(anyhow::anyhow!("Unable to decrypt your master key")),
             };
 
             let mut master_key = [0u8; 32];
@@ -225,7 +228,6 @@ pub fn stream_mode(
             Protected::new(master_key)
         }
     };
-
 
     let decrypt_start_time = Instant::now();
 

--- a/src/subcommands/encrypt.rs
+++ b/src/subcommands/encrypt.rs
@@ -13,9 +13,9 @@ use dexios_core::primitives::Algorithm;
 use dexios_core::primitives::Mode;
 use dexios_core::protected::Protected;
 use paris::Logger;
+use rand::prelude::StdRng;
 use rand::RngCore;
 use rand::SeedableRng;
-use rand::prelude::StdRng;
 use std::fs::File;
 use std::io::Write;
 use std::process::exit;
@@ -82,7 +82,7 @@ pub fn stream_mode(
 
     let master_key_encrypted = match master_key_result {
         std::result::Result::Ok(bytes) => bytes,
-        Err(_) => return Err(anyhow::anyhow!("Unable to encrypt your master key"))
+        Err(_) => return Err(anyhow::anyhow!("Unable to encrypt your master key")),
     };
 
     let nonce = gen_nonce(&header_type.algorithm, &header_type.mode);

--- a/src/subcommands/pack.rs
+++ b/src/subcommands/pack.rs
@@ -13,7 +13,10 @@ use zip::write::FileOptions;
 
 use crate::{
     global::states::{DirectoryMode, EraseSourceDir, PrintMode},
-    global::{structs::{CryptoParams, PackParams}, states::Compression},
+    global::{
+        states::Compression,
+        structs::{CryptoParams, PackParams},
+    },
 };
 
 // this first indexes the input directory
@@ -47,18 +50,14 @@ pub fn pack(
     let mut zip = zip::ZipWriter::new(file);
 
     let options = match pack_params.compression {
-        Compression::None => {
-            FileOptions::default()
-                .compression_method(zip::CompressionMethod::Stored)
-                .large_file(true)
-                .unix_permissions(0o755)
-        }
-        Compression::Zstd => {
-            FileOptions::default()
+        Compression::None => FileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored)
+            .large_file(true)
+            .unix_permissions(0o755),
+        Compression::Zstd => FileOptions::default()
             .compression_method(zip::CompressionMethod::Zstd)
             .large_file(true)
-            .unix_permissions(0o755)
-        }
+            .unix_permissions(0o755),
     };
 
     let mut item_count = 0;
@@ -81,23 +80,20 @@ pub fn pack(
         let item_data = item.context("Unable to get path of item, skipping")?;
         let item = item_data.path();
 
-        let item_str = item.to_str().context("Error converting directory path to string")?.replace(r"\", "/");
+        let item_str = item
+            .to_str()
+            .context("Error converting directory path to string")?
+            .replace(r"\", "/");
 
         if item.is_dir() {
-            zip.add_directory(
-                item_str,
-                options,
-            )
-            .context("Unable to add directory to zip")?;
+            zip.add_directory(item_str, options)
+                .context("Unable to add directory to zip")?;
 
             continue;
         }
 
-        zip.start_file(
-            item_str,
-            options,
-        )
-        .context("Unable to add file to zip")?;
+        zip.start_file(item_str, options)
+            .context("Unable to add file to zip")?;
 
         if pack_params.print_mode == PrintMode::Verbose {
             logger.info(format!(

--- a/src/subcommands/pack.rs
+++ b/src/subcommands/pack.rs
@@ -83,7 +83,7 @@ pub fn pack(
         let item_str = item
             .to_str()
             .context("Error converting directory path to string")?
-            .replace(r"\", "/");
+            .replace('\\', "/");
 
         if item.is_dir() {
             zip.add_directory(item_str, options)

--- a/src/subcommands/pack.rs
+++ b/src/subcommands/pack.rs
@@ -13,7 +13,7 @@ use zip::write::FileOptions;
 
 use crate::{
     global::states::{DirectoryMode, EraseSourceDir, PrintMode},
-    global::structs::{CryptoParams, PackParams},
+    global::{structs::{CryptoParams, PackParams}, states::Compression},
 };
 
 // this first indexes the input directory
@@ -45,10 +45,21 @@ pub fn pack(
     let zip_start_time = Instant::now();
 
     let mut zip = zip::ZipWriter::new(file);
-    let options = FileOptions::default()
-        .compression_method(zip::CompressionMethod::Stored)
-        .large_file(true)
-        .unix_permissions(0o755);
+
+    let options = match pack_params.compression {
+        Compression::None => {
+            FileOptions::default()
+                .compression_method(zip::CompressionMethod::Stored)
+                .large_file(true)
+                .unix_permissions(0o755)
+        }
+        Compression::Zstd => {
+            FileOptions::default()
+            .compression_method(zip::CompressionMethod::Zstd)
+            .large_file(true)
+            .unix_permissions(0o755)
+        }
+    };
 
     let mut item_count = 0;
 


### PR DESCRIPTION
This branch adds a `-z` switch to `pack` mode.

It uses the `zip` crate's defaults (ZSTD compression level = 3), and I have confirmed it to be fully working.

Your mileage will vary depending on the entropy of the files you are packing - high entropy means less room for compression.

I would **not** recommend using `-z` to pack already-encrypted files. There are no benefits to that.

This implements #79.