### PR TITLE
Detached Header Rework

### DIFF
--- a/.github/workflows/dexios-tests.yml
+++ b/.github/workflows/dexios-tests.yml
@@ -92,6 +92,10 @@ jobs:
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios header strip -y 100MB.enc
     - name: Decrypt in stream mode with detached header (XChaCha20-Poly1305)
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -dHyk keyfile --header 100MB.enc.header 100MB.enc 100MB.bin
+    - name: Encrypt in stream mode to detached header (XChaCha20-Poly1305)
+      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -eHyk keyfile --header 100MB.header 100MB.bin 100MB.enc
+    - name: Decrypt in stream mode with detached header (XChaCha20-Poly1305)
+      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -dHyk keyfile --header 100MB.header 100MB.enc 100MB.bin
   hash-standalone-mode:
     needs: build
     runs-on: ubuntu-latest

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,6 +55,13 @@ pub fn get_matches() -> clap::ArgMatches {
                 .conflicts_with("keyfile"),
         )
         .arg(
+            Arg::new("header")
+                .long("header")
+                .value_name("file")
+                .takes_value(true)
+                .help("Store the header separately from the file"),
+        )
+        .arg(
             Arg::new("skip")
                 .short('y')
                 .long("skip")
@@ -232,6 +239,13 @@ pub fn get_matches() -> clap::ArgMatches {
                     .takes_value(false)
                     .help("Autogenerate a passphrase")
                     .conflicts_with("keyfile"),
+            )
+            .arg(
+                Arg::new("header")
+                    .long("header")
+                    .value_name("file")
+                    .takes_value(true)
+                    .help("Store the header separately from the file"),
             )
             .arg(
                 Arg::new("zstd")

--- a/src/global/parameters.rs
+++ b/src/global/parameters.rs
@@ -80,7 +80,7 @@ pub fn parameter_handler(sub_matches: &ArgMatches) -> Result<CryptoParams> {
         skip,
         erase,
         key,
-        header_location
+        header_location,
     })
 }
 

--- a/src/global/parameters.rs
+++ b/src/global/parameters.rs
@@ -1,7 +1,7 @@
 // this file handles getting parameters from clap's ArgMatches
 // it returns information (e.g. CryptoParams) to functions that require it
 
-use crate::global::states::{EraseMode, EraseSourceDir, HashMode, HeaderFile, SkipMode};
+use crate::global::states::{EraseMode, EraseSourceDir, HashMode, HeaderLocation, SkipMode};
 use crate::global::structs::CryptoParams;
 use crate::global::structs::PackParams;
 use anyhow::{Context, Result};
@@ -94,16 +94,16 @@ pub fn encrypt_additional_params(sub_matches: &ArgMatches) -> Result<Algorithm> 
     }
 }
 
-pub fn decrypt_additional_params(sub_matches: &ArgMatches) -> Result<HeaderFile> {
+pub fn decrypt_additional_params(sub_matches: &ArgMatches) -> Result<HeaderLocation> {
     let header = if sub_matches.is_present("header") {
-        HeaderFile::Some(
+        HeaderLocation::Detached(
             sub_matches
                 .value_of("header")
                 .context("No header/invalid text provided")?
                 .to_string(),
         )
     } else {
-        HeaderFile::None
+        HeaderLocation::Embedded
     };
 
     Ok(header)

--- a/src/global/parameters.rs
+++ b/src/global/parameters.rs
@@ -64,11 +64,23 @@ pub fn parameter_handler(sub_matches: &ArgMatches) -> Result<CryptoParams> {
         EraseMode::IgnoreFile(0)
     };
 
+    let header_location = if sub_matches.is_present("header") {
+        HeaderLocation::Detached(
+            sub_matches
+                .value_of("header")
+                .context("No header/invalid text provided")?
+                .to_string(),
+        )
+    } else {
+        HeaderLocation::Embedded
+    };
+
     Ok(CryptoParams {
         hash_mode,
         skip,
         erase,
         key,
+        header_location
     })
 }
 
@@ -92,21 +104,6 @@ pub fn encrypt_additional_params(sub_matches: &ArgMatches) -> Result<Algorithm> 
     } else {
         Ok(ALGORITHMS[provided_aead - 1]) // -1 to account for indexing starting at 0
     }
-}
-
-pub fn decrypt_additional_params(sub_matches: &ArgMatches) -> Result<HeaderLocation> {
-    let header = if sub_matches.is_present("header") {
-        HeaderLocation::Detached(
-            sub_matches
-                .value_of("header")
-                .context("No header/invalid text provided")?
-                .to_string(),
-        )
-    } else {
-        HeaderLocation::Embedded
-    };
-
-    Ok(header)
 }
 
 pub fn erase_params(sub_matches: &ArgMatches) -> Result<i32> {
@@ -157,11 +154,23 @@ pub fn pack_params(sub_matches: &ArgMatches) -> Result<(CryptoParams, PackParams
 
     let erase = EraseMode::IgnoreFile(0);
 
+    let header_location = if sub_matches.is_present("header") {
+        HeaderLocation::Detached(
+            sub_matches
+                .value_of("header")
+                .context("No header/invalid text provided")?
+                .to_string(),
+        )
+    } else {
+        HeaderLocation::Embedded
+    };
+
     let crypto_params = CryptoParams {
         hash_mode,
         skip,
         erase,
         key,
+        header_location,
     };
 
     let print_mode = if sub_matches.is_present("verbose") {

--- a/src/global/states.rs
+++ b/src/global/states.rs
@@ -41,6 +41,11 @@ pub enum PrintMode {
     Quiet,
 }
 
+pub enum HeaderLocation {
+    Embedded,
+    Detached(String),
+}
+
 #[derive(PartialEq, Clone, Copy)]
 pub enum EraseMode {
     EraseFile(i32),
@@ -101,11 +106,6 @@ impl Key {
             Ok(secret)
         }
     }
-}
-
-pub enum HeaderFile {
-    Some(String),
-    None,
 }
 
 impl EraseMode {

--- a/src/global/structs.rs
+++ b/src/global/structs.rs
@@ -1,12 +1,13 @@
 use crate::global::states::{HashMode, SkipMode};
 
-use super::states::{Compression, DirectoryMode, EraseMode, EraseSourceDir, Key, PrintMode};
+use super::states::{Compression, DirectoryMode, EraseMode, EraseSourceDir, Key, PrintMode, HeaderLocation};
 
 pub struct CryptoParams {
     pub hash_mode: HashMode,
     pub skip: SkipMode,
     pub erase: EraseMode,
     pub key: Key,
+    pub header_location: HeaderLocation,
 }
 
 pub struct PackParams {

--- a/src/global/structs.rs
+++ b/src/global/structs.rs
@@ -1,6 +1,8 @@
 use crate::global::states::{HashMode, SkipMode};
 
-use super::states::{Compression, DirectoryMode, EraseMode, EraseSourceDir, Key, PrintMode, HeaderLocation};
+use super::states::{
+    Compression, DirectoryMode, EraseMode, EraseSourceDir, HeaderLocation, Key, PrintMode,
+};
 
 pub struct CryptoParams {
     pub hash_mode: HashMode,

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -5,7 +5,7 @@ use clap::ArgMatches;
 // it gets params and sends them to the appropriate functions
 
 use crate::global::parameters::{
-    decrypt_additional_params, encrypt_additional_params, erase_params, get_param, pack_params,
+    encrypt_additional_params, erase_params, get_param, pack_params,
     parameter_handler,
 };
 
@@ -35,13 +35,12 @@ pub fn encrypt(sub_matches: &ArgMatches) -> Result<()> {
 
 pub fn decrypt(sub_matches: &ArgMatches) -> Result<()> {
     let params = parameter_handler(sub_matches)?;
-    let header = decrypt_additional_params(sub_matches)?;
+    // let header = decrypt_additional_params(sub_matches)?;
 
     // stream decrypt is the default as it will redirect to memory mode if the header says so (for backwards-compat)
     decrypt::stream_mode(
         &get_param("input", sub_matches)?,
         &get_param("output", sub_matches)?,
-        &header,
         &params,
     )
 }
@@ -69,7 +68,6 @@ pub fn unpack(sub_matches: &ArgMatches) -> Result<()> {
     use super::global::states::PrintMode;
 
     let crypto_params = parameter_handler(sub_matches)?;
-    let header = decrypt_additional_params(sub_matches)?;
 
     let print_mode = if sub_matches.is_present("verbose") {
         //specify to emit hash after operation
@@ -82,7 +80,6 @@ pub fn unpack(sub_matches: &ArgMatches) -> Result<()> {
     unpack::unpack(
         &get_param("input", sub_matches)?,
         &get_param("output", sub_matches)?,
-        &header,
         &print_mode,
         &crypto_params,
     )

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -5,8 +5,7 @@ use clap::ArgMatches;
 // it gets params and sends them to the appropriate functions
 
 use crate::global::parameters::{
-    encrypt_additional_params, erase_params, get_param, pack_params,
-    parameter_handler,
+    encrypt_additional_params, erase_params, get_param, pack_params, parameter_handler,
 };
 
 pub mod decrypt;

--- a/src/subcommands/decrypt.rs
+++ b/src/subcommands/decrypt.rs
@@ -215,7 +215,7 @@ pub fn stream_mode(
                 std::result::Result::Ok(bytes) => bytes,
                 Err(_) => {
                     return Err(anyhow::anyhow!(
-                        "Unable to decrypt your master key (maybe you supplied a wrong key?)"
+                        "Unable to decrypt your master key (maybe you supplied the wrong key?)"
                     ))
                 }
             };

--- a/src/subcommands/decrypt.rs
+++ b/src/subcommands/decrypt.rs
@@ -33,11 +33,7 @@ use dexios_core::stream::DecryptionStreams;
 // it also manages using a detached header file if selected
 // it creates the Cipher object, and uses that for decryption
 // it then writes the decrypted data to the file
-pub fn memory_mode(
-    input: &str,
-    output: &str,
-    params: &CryptoParams,
-) -> Result<()> {
+pub fn memory_mode(input: &str, output: &str, params: &CryptoParams) -> Result<()> {
     let mut logger = Logger::new();
 
     if !overwrite_check(output, params.skip)? {
@@ -137,11 +133,7 @@ pub fn memory_mode(
 // it handles any user-facing interactiveness, opening files, or redirecting to memory mode if the header says so (backwards-compat)
 // it also manages using a detached header file if selected
 // it creates the stream object and uses the convenience function provided by dexios-core
-pub fn stream_mode(
-    input: &str,
-    output: &str,
-    params: &CryptoParams,
-) -> Result<()> {
+pub fn stream_mode(input: &str, output: &str, params: &CryptoParams) -> Result<()> {
     let mut logger = Logger::new();
 
     if input == output {

--- a/src/subcommands/decrypt.rs
+++ b/src/subcommands/decrypt.rs
@@ -36,7 +36,6 @@ use dexios_core::stream::DecryptionStreams;
 pub fn memory_mode(
     input: &str,
     output: &str,
-    header_file: &HeaderLocation,
     params: &CryptoParams,
 ) -> Result<()> {
     let mut logger = Logger::new();
@@ -48,7 +47,7 @@ pub fn memory_mode(
     let mut input_file =
         File::open(input).with_context(|| format!("Unable to open input file: {}", input))?;
 
-    let (header, aad) = match header_file {
+    let (header, aad) = match &params.header_location {
         HeaderLocation::Detached(contents) => {
             let mut header_file = File::open(contents)
                 .with_context(|| format!("Unable to open header file: {}", input))?;
@@ -141,7 +140,6 @@ pub fn memory_mode(
 pub fn stream_mode(
     input: &str,
     output: &str,
-    header_file: &HeaderLocation,
     params: &CryptoParams,
 ) -> Result<()> {
     let mut logger = Logger::new();
@@ -155,7 +153,7 @@ pub fn stream_mode(
     let mut input_file =
         File::open(input).with_context(|| format!("Unable to open input file: {}", input))?;
 
-    let (header, aad) = match header_file {
+    let (header, aad) = match &params.header_location {
         HeaderLocation::Detached(contents) => {
             let mut header_file = File::open(contents)
                 .with_context(|| format!("Unable to open header file: {}", input))?;
@@ -170,7 +168,7 @@ pub fn stream_mode(
 
     if header.header_type.mode == Mode::MemoryMode {
         drop(input_file);
-        return memory_mode(input, output, header_file, params);
+        return memory_mode(input, output, params);
     }
 
     if !overwrite_check(output, params.skip)? {

--- a/src/subcommands/encrypt.rs
+++ b/src/subcommands/encrypt.rs
@@ -1,6 +1,7 @@
 use super::prompt::overwrite_check;
 use crate::global::states::EraseMode;
 use crate::global::states::HashMode;
+use crate::global::states::HeaderLocation;
 use crate::global::states::PasswordState;
 use crate::global::structs::CryptoParams;
 use anyhow::Context;
@@ -17,6 +18,7 @@ use rand::prelude::StdRng;
 use rand::RngCore;
 use rand::SeedableRng;
 use std::fs::File;
+use std::io::Seek;
 use std::io::Write;
 use std::process::exit;
 use std::time::Instant;
@@ -96,7 +98,24 @@ pub fn stream_mode(
         master_key_nonce: Some(master_key_nonce),
     };
 
-    header.write(&mut output_file)?;
+    match &params.header_location {
+        HeaderLocation::Embedded => {
+            header.write(&mut output_file)?;
+        }
+        HeaderLocation::Detached(path) => {
+            if !overwrite_check(path, params.skip)? {
+                exit(0);
+            }
+
+            let mut header_file = File::create(path).context("Unable to create file for the header")?;
+
+            header.write(&mut header_file).context("Unable to write header to the file")?;
+
+            let header_size = header.get_size().try_into().context("Unable to get header size as i64")?;
+            output_file.seek(std::io::SeekFrom::Current(header_size))?;
+        }
+    }
+
 
     let aad = header.create_aad()?;
 

--- a/src/subcommands/encrypt.rs
+++ b/src/subcommands/encrypt.rs
@@ -107,15 +107,20 @@ pub fn stream_mode(
                 exit(0);
             }
 
-            let mut header_file = File::create(path).context("Unable to create file for the header")?;
+            let mut header_file =
+                File::create(path).context("Unable to create file for the header")?;
 
-            header.write(&mut header_file).context("Unable to write header to the file")?;
+            header
+                .write(&mut header_file)
+                .context("Unable to write header to the file")?;
 
-            let header_size = header.get_size().try_into().context("Unable to get header size as i64")?;
+            let header_size = header
+                .get_size()
+                .try_into()
+                .context("Unable to get header size as i64")?;
             output_file.seek(std::io::SeekFrom::Current(header_size))?;
         }
     }
-
 
     let aad = header.create_aad()?;
 

--- a/src/subcommands/header.rs
+++ b/src/subcommands/header.rs
@@ -79,7 +79,7 @@ pub fn update_key(input: &str, key_old: &Key, key_new: &Key) -> Result<()> {
         std::result::Result::Ok(bytes) => bytes,
         Err(_) => {
             return Err(anyhow::anyhow!(
-                "Unable to decrypt your master key (maybe you supplied a wrong key?)"
+                "Unable to decrypt your master key (maybe you supplied the wrong key?)"
             ))
         }
     };

--- a/src/subcommands/header.rs
+++ b/src/subcommands/header.rs
@@ -246,7 +246,8 @@ pub fn strip(input: &str, skip: SkipMode) -> Result<()> {
     input_file
         .write_all(&vec![
             0;
-            header_size.try_into()
+            header_size
+                .try_into()
                 .context("Error getting header's size as usize")?
         ])
         .with_context(|| format!("Unable to wipe header for file: {}", input))?;

--- a/src/subcommands/header.rs
+++ b/src/subcommands/header.rs
@@ -234,19 +234,19 @@ pub fn strip(input: &str, skip: SkipMode) -> Result<()> {
     }
 
     let (header, _) = header_result.context("Error unwrapping the header's result")?; // this should never happen
-    let size: i64 = header
+    let header_size: i64 = header
         .get_size()
         .try_into()
         .context("Error getting header's size as i64")?;
 
     input_file
-        .seek(std::io::SeekFrom::Current(-size))
+        .seek(std::io::SeekFrom::Current(-header_size))
         .context("Unable to seek back to the start of the file")?;
 
     input_file
         .write_all(&vec![
             0;
-            size.try_into()
+            header_size.try_into()
                 .context("Error getting header's size as usize")?
         ])
         .with_context(|| format!("Unable to wipe header for file: {}", input))?;

--- a/src/subcommands/unpack.rs
+++ b/src/subcommands/unpack.rs
@@ -19,7 +19,6 @@ use super::prompt::get_answer;
 pub fn unpack(
     input: &str,         // encrypted zip file
     output: &str,        // directory
-    header: &HeaderLocation, // for decrypt function
     print_mode: &PrintMode,
     params: &CryptoParams, // params for decrypt function
 ) -> Result<()> {
@@ -29,7 +28,7 @@ pub fn unpack(
     // this is the name of the decrypted zip file
     let tmp_name = format!("{}.{}", input, random_extension); // e.g. "input.kjHSD93l"
 
-    super::decrypt::stream_mode(input, &tmp_name, header, params)?;
+    super::decrypt::stream_mode(input, &tmp_name, params)?;
 
     let zip_start_time = Instant::now();
     let file = File::open(&tmp_name).context("Unable to open temporary archive")?;

--- a/src/subcommands/unpack.rs
+++ b/src/subcommands/unpack.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use rand::distributions::{Alphanumeric, DistString};
 
 use crate::global::{
-    states::{HeaderFile, PrintMode, SkipMode},
+    states::{HeaderLocation, PrintMode, SkipMode},
     structs::CryptoParams,
 };
 use paris::Logger;
@@ -19,7 +19,7 @@ use super::prompt::get_answer;
 pub fn unpack(
     input: &str,         // encrypted zip file
     output: &str,        // directory
-    header: &HeaderFile, // for decrypt function
+    header: &HeaderLocation, // for decrypt function
     print_mode: &PrintMode,
     params: &CryptoParams, // params for decrypt function
 ) -> Result<()> {

--- a/src/subcommands/unpack.rs
+++ b/src/subcommands/unpack.rs
@@ -17,8 +17,8 @@ use super::prompt::get_answer;
 // once finished, it erases the temporary file to avoid any residual data
 #[allow(clippy::module_name_repetitions)]
 pub fn unpack(
-    input: &str,         // encrypted zip file
-    output: &str,        // directory
+    input: &str,  // encrypted zip file
+    output: &str, // directory
     print_mode: &PrintMode,
     params: &CryptoParams, // params for decrypt function
 ) -> Result<()> {

--- a/src/subcommands/unpack.rs
+++ b/src/subcommands/unpack.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use rand::distributions::{Alphanumeric, DistString};
 
 use crate::global::{
-    states::{HeaderLocation, PrintMode, SkipMode},
+    states::{PrintMode, SkipMode},
     structs::CryptoParams,
 };
 use paris::Logger;


### PR DESCRIPTION
This refactors how detached headers are handled, and implements support for encrypting and storing the header elsewhere.

The header will never be written with the encrypted data, if `--header` and a different file/path is supplied.

You will need to either use `dexios header restore`, or decrypt with a detached header in order to decrypt your data.

This relates to #73.