### PR TITLE
Migrate to `hash_into`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "argon2"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27e27b63e4a34caee411ade944981136fdfa535522dc9944d6700196cbd899f"
+checksum = "db4ce4441f99dbd377ca8a8f57b698c44d0d6e712d8329b5040da5a64aa1ce73"
 dependencies = [
  "base64ct",
  "blake2",
@@ -85,9 +85,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "balloon-hash"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c513ebf2e5559f2ba30b8780f2eee89c8a69842734441a536a4be2f5cab7612"
+checksum = "1fdbafd8c776e0a7c250b5dfaf4723477e0d92b42c5a91ce4e50bd9bb2dcc9a1"
 dependencies = [
  "crypto-bigint",
  "digest",

--- a/dexios-core/Cargo.toml
+++ b/dexios-core/Cargo.toml
@@ -31,8 +31,8 @@ aead = { version = "0.4.3", features = ["stream"] }
 zeroize = "1.3.0"
 
 # for password hashing
-argon2 = "0.4.0"
-balloon-hash = "0.2.1"
+argon2 = "0.4.1"
+balloon-hash = "0.3.0"
 blake3 = { version = "1.3.1", features = ["traits-preview"] }
 
 # for generating random bytes

--- a/dexios-core/src/key.rs
+++ b/dexios-core/src/key.rs
@@ -19,7 +19,6 @@ use anyhow::Result;
 use rand::prelude::StdRng;
 use rand::RngCore;
 use rand::SeedableRng;
-use zeroize::Zeroize;
 
 /// This generates a salt, of the specified `SALT_LEN`
 ///


### PR DESCRIPTION
With the release of balloon-hash v0.3.0, `hash_into` was provided as a function you may use to prevent reallocation. This means we no longer need to manually `zeroize` everything the hashed key has touched.