### PR TITLE
cli: remove password option from pack and unpack

### DIFF
--- a/dexios/src/cli.rs
+++ b/dexios/src/cli.rs
@@ -278,14 +278,6 @@ pub fn get_matches() -> clap::ArgMatches {
                     .help("Skip all prompts"),
             )
             .arg(
-                Arg::new("password")
-                    .short('p')
-                    .long("password")
-                    .takes_value(false)
-                    .help("Interactively ask for your password")
-                    .conflicts_with("keyfile"),
-            )
-            .arg(
                 Arg::new("aead")
                     .short('a')
                     .long("aead")
@@ -358,14 +350,6 @@ pub fn get_matches() -> clap::ArgMatches {
                         .takes_value(false)
                         .help("Skip all prompts"),
                 )
-                .arg(
-                    Arg::new("password")
-                        .short('p')
-                        .long("password")
-                        .takes_value(false)
-                        .help("Interactively ask for your password")
-                        .conflicts_with("keyfile"),
-                ),
         )
         .subcommand(
             Command::new("header")


### PR DESCRIPTION
You forgot to remove password from `pack` and `unpack` commands

mentioned #100