### PR TITLE
cli: fix executing pack command

### DIFF
--- a/dexios/src/cli.rs
+++ b/dexios/src/cli.rs
@@ -254,16 +254,6 @@ pub fn get_matches() -> clap::ArgMatches {
                     .help("Use a keyfile instead of a password"),
             )
             .arg(
-                Arg::new("erase")
-                    .long("erase")
-                    .value_name("# of passes")
-                    .takes_value(true)
-                    .require_equals(true)
-                    .help("Securely erase the input file once complete (default is 2 passes)")
-                    .min_values(0)
-                    .default_missing_value("2"),
-            )
-            .arg(
                 Arg::new("hash")
                     .short('H')
                     .long("hash")


### PR DESCRIPTION
I've started working on task #99 and found this problem. I cannot run `pack` subcommand on the master.

```
thread 'main' panicked at 'Command pack: Argument names must be unique, but 'erase' is in use by more than one argument or group', /home/janabhumi/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.2.8/src/builder/debug_asserts.rs:100:9
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: clap::builder::debug_asserts::assert_app
             at /home/janabhumi/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.2.8/src/builder/debug_asserts.rs:100:9
   3: clap::builder::command::App::_build_self
             at /home/janabhumi/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.2.8/src/builder/command.rs:4300:13
   4: clap::builder::command::App::_build_subcommand
             at /home/janabhumi/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.2.8/src/builder/command.rs:4384:9
   5: clap::parser::parser::Parser::parse_subcommand
             at /home/janabhumi/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.2.8/src/parser/parser.rs:676:27
   6: clap::parser::parser::Parser::get_matches_with
             at /home/janabhumi/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.2.8/src/parser/parser.rs:469:13
   7: clap::builder::command::App::_do_parse
             at /home/janabhumi/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.2.8/src/builder/command.rs:4164:29
   8: clap::builder::command::App::try_get_matches_from_mut
             at /home/janabhumi/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.2.8/src/builder/command.rs:730:9
   9: clap::builder::command::App::get_matches_from
             at /home/janabhumi/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.2.8/src/builder/command.rs:600:9
  10: clap::builder::command::App::get_matches
             at /home/janabhumi/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.2.8/src/builder/command.rs:512:9
  11: dexios::cli::get_matches
             at ./dexios/src/cli.rs:137:5
  12: dexios::main
             at ./dexios/src/main.rs:18:19
  13: core::ops::function::FnOnce::call_once
             at /build/rustc-1.61.0-src/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```