### PR TITLE
Improvements

### DIFF
--- a/dexios-core/src/cipher.rs
+++ b/dexios-core/src/cipher.rs
@@ -54,32 +54,20 @@ impl Ciphers {
     pub fn initialize(key: Protected<[u8; 32]>, algorithm: &Algorithm) -> anyhow::Result<Self> {
         let cipher = match algorithm {
             Algorithm::Aes256Gcm => {
-                let cipher = match Aes256Gcm::new_from_slice(key.expose()) {
-                    Ok(cipher) => cipher,
-                    Err(_) => {
-                        return Err(anyhow::anyhow!("Unable to create cipher with hashed key."))
-                    }
-                };
+                let cipher = Aes256Gcm::new_from_slice(key.expose())
+                    .map_err(|_| anyhow::anyhow!("Unable to create cipher with hashed key."))?;
 
                 Ciphers::Aes256Gcm(Box::new(cipher))
             }
             Algorithm::XChaCha20Poly1305 => {
-                let cipher = match XChaCha20Poly1305::new_from_slice(key.expose()) {
-                    Ok(cipher) => cipher,
-                    Err(_) => {
-                        return Err(anyhow::anyhow!("Unable to create cipher with hashed key."))
-                    }
-                };
+                let cipher = XChaCha20Poly1305::new_from_slice(key.expose())
+                    .map_err(|_| anyhow::anyhow!("Unable to create cipher with hashed key."))?;
 
                 Ciphers::XChaCha(Box::new(cipher))
             }
             Algorithm::DeoxysII256 => {
-                let cipher = match DeoxysII256::new_from_slice(key.expose()) {
-                    Ok(cipher) => cipher,
-                    Err(_) => {
-                        return Err(anyhow::anyhow!("Unable to create cipher with hashed key."))
-                    }
-                };
+                let cipher = DeoxysII256::new_from_slice(key.expose())
+                    .map_err(|_| anyhow::anyhow!("Unable to create cipher with hashed key."))?;
 
                 Ciphers::DeoxysII(Box::new(cipher))
             }

--- a/dexios-core/src/key.rs
+++ b/dexios-core/src/key.rs
@@ -67,27 +67,18 @@ pub fn argon2id_hash(
     let params = match version {
         HeaderVersion::V1 => {
             // 8MiB of memory, 8 iterations, 4 levels of parallelism
-            let params = Params::new(8192, 8, 4, Some(Params::DEFAULT_OUTPUT_LEN));
-            match params {
-                std::result::Result::Ok(parameters) => parameters,
-                Err(_) => return Err(anyhow::anyhow!("Error initialising argon2id parameters")),
-            }
+            Params::new(8192, 8, 4, Some(Params::DEFAULT_OUTPUT_LEN))
+                .map_err(|_| anyhow::anyhow!("Error initialising argon2id parameters"))?
         }
         HeaderVersion::V2 => {
             // 256MiB of memory, 8 iterations, 4 levels of parallelism
-            let params = Params::new(262_144, 8, 4, Some(Params::DEFAULT_OUTPUT_LEN));
-            match params {
-                std::result::Result::Ok(parameters) => parameters,
-                Err(_) => return Err(anyhow::anyhow!("Error initialising argon2id parameters")),
-            }
+            Params::new(262_144, 8, 4, Some(Params::DEFAULT_OUTPUT_LEN))
+                .map_err(|_| anyhow::anyhow!("Error initialising argon2id parameters"))?
         }
         HeaderVersion::V3 => {
             // 256MiB of memory, 10 iterations, 4 levels of parallelism
-            let params = Params::new(262_144, 10, 4, Some(Params::DEFAULT_OUTPUT_LEN));
-            match params {
-                std::result::Result::Ok(parameters) => parameters,
-                Err(_) => return Err(anyhow::anyhow!("Error initialising argon2id parameters")),
-            }
+            Params::new(262_144, 10, 4, Some(Params::DEFAULT_OUTPUT_LEN))
+                .map_err(|_| anyhow::anyhow!("Error initialising argon2id parameters"))?
         }
         HeaderVersion::V4 => {
             return Err(anyhow::anyhow!(
@@ -140,19 +131,10 @@ pub fn balloon_hash(
         HeaderVersion::V1 | HeaderVersion::V2 | HeaderVersion::V3 => {
             return Err(anyhow::anyhow!(
                 "Balloon hashing is not supported in header versions below V4."
-            ))
+            ));
         }
-        HeaderVersion::V4 => {
-            let params = balloon_hash::Params::new(262_144, 1, 1);
-            match params {
-                Ok(parameters) => parameters,
-                Err(_) => {
-                    return Err(anyhow::anyhow!(
-                        "Error initialising balloon hashing parameters"
-                    ))
-                }
-            }
-        }
+        HeaderVersion::V4 => balloon_hash::Params::new(262_144, 1, 1)
+            .map_err(|_| anyhow::anyhow!("Error initialising balloon hashing parameters"))?,
     };
 
     let mut key = [0u8; 32];

--- a/dexios/src/domain/mod.rs
+++ b/dexios/src/domain/mod.rs
@@ -1,3 +1,3 @@
-pub mod erase;
 pub mod hash;
 pub mod hasher;
+pub mod overwrite;

--- a/dexios/src/domain/overwrite.rs
+++ b/dexios/src/domain/overwrite.rs
@@ -99,23 +99,28 @@ mod tests {
     }
 
     #[test]
-    fn should_erase_empty_content() {
+    fn should_overwrite_empty_content() {
         make_test(0, 1);
     }
 
     #[test]
-    fn should_erase_small_content() {
+    fn should_overwrite_small_content() {
         make_test(100, 1);
     }
 
     #[test]
-    fn should_erase_perfectly_divisible_content() {
+    fn should_overwrite_perfectly_divisible_content() {
         make_test(BLOCK_SIZE, 1);
     }
 
     #[test]
-    fn should_erase_not_perfectly_divisible_content() {
+    fn should_overwrite_not_perfectly_divisible_content() {
         make_test(515, 1);
+    }
+
+    #[test]
+    fn should_overwrite_large_content() {
+        make_test(BLOCK_SIZE * 100, 1);
     }
 
     #[test]

--- a/dexios/src/main.rs
+++ b/dexios/src/main.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use global::parameters::get_param;
 use global::parameters::key_update_params;
 use global::parameters::skipmode;
-use std::result::Result::Ok;
 use subcommands::list::show_values;
 
 mod cli;

--- a/dexios/src/subcommands/decrypt.rs
+++ b/dexios/src/subcommands/decrypt.rs
@@ -206,10 +206,8 @@ pub fn stream_mode(input: &str, output: &str, params: &CryptoParams) -> Result<(
             })?;
 
             let mut master_key = [0u8; 32];
-
-            for (i, byte) in master_key_decrypted.iter().enumerate() {
-                master_key[i] = *byte;
-            }
+            let len = 32.min(master_key_decrypted.len());
+            master_key[..len].copy_from_slice(&master_key_decrypted[..len]);
 
             master_key_decrypted.zeroize();
             Protected::new(master_key)

--- a/dexios/src/subcommands/encrypt.rs
+++ b/dexios/src/subcommands/encrypt.rs
@@ -5,7 +5,7 @@ use crate::global::states::HeaderLocation;
 use crate::global::states::PasswordState;
 use crate::global::structs::CryptoParams;
 use anyhow::Context;
-use anyhow::{Ok, Result};
+use anyhow::Result;
 use dexios_core::cipher::Ciphers;
 use dexios_core::header::{Header, HeaderType, HEADER_VERSION};
 use dexios_core::key::{balloon_hash, gen_salt};
@@ -82,10 +82,8 @@ pub fn stream_mode(
     let cipher = Ciphers::initialize(key, &header_type.algorithm)?;
     let master_key_result = cipher.encrypt(&master_key_nonce, master_key.expose().as_slice());
 
-    let master_key_encrypted = match master_key_result {
-        std::result::Result::Ok(bytes) => bytes,
-        Err(_) => return Err(anyhow::anyhow!("Unable to encrypt your master key")),
-    };
+    let master_key_encrypted =
+        master_key_result.map_err(|_| anyhow::anyhow!("Unable to encrypt your master key"))?;
 
     let nonce = gen_nonce(&header_type.algorithm, &header_type.mode);
     let streams = EncryptionStreams::initialize(master_key, &nonce, &header_type.algorithm)?;

--- a/dexios/src/subcommands/erase.rs
+++ b/dexios/src/subcommands/erase.rs
@@ -58,7 +58,7 @@ pub fn secure_erase(input: &str, passes: i32) -> Result<()> {
     let file = File::create(input).with_context(|| format!("Unable to open file: {}", input))?;
     let buf_capacity = file_meta.len() as usize;
 
-    domain::erase::execute(domain::erase::Request {
+    domain::overwrite::execute(domain::overwrite::Request {
         writer: RefCell::new(BufWriter::new(file)),
         buf_capacity,
         passes,

--- a/dexios/src/subcommands/hashing.rs
+++ b/dexios/src/subcommands/hashing.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use anyhow::{Ok, Result};
+use anyhow::Result;
 use paris::Logger;
 use std::cell::RefCell;
 

--- a/dexios/src/subcommands/header.rs
+++ b/dexios/src/subcommands/header.rs
@@ -80,14 +80,9 @@ pub fn update_key(input: &str, key_old: &Key, key_new: &Key) -> Result<()> {
     let cipher = Ciphers::initialize(key_old, &header.header_type.algorithm)?;
 
     let master_key_result = cipher.decrypt(&master_key_nonce, master_key_encrypted.as_slice());
-    let mut master_key_decrypted = match master_key_result {
-        std::result::Result::Ok(bytes) => bytes,
-        Err(_) => {
-            return Err(anyhow::anyhow!(
-                "Unable to decrypt your master key (maybe you supplied the wrong key?)"
-            ))
-        }
-    };
+    let mut master_key_decrypted = master_key_result.map_err(|_| {
+        anyhow::anyhow!("Unable to decrypt your master key (maybe you supplied the wrong key?)")
+    })?;
 
     let mut master_key = [0u8; 32];
 
@@ -107,10 +102,8 @@ pub fn update_key(input: &str, key_old: &Key, key_new: &Key) -> Result<()> {
 
     drop(master_key);
 
-    let master_key_encrypted = match master_key_result {
-        std::result::Result::Ok(bytes) => bytes,
-        Err(_) => return Err(anyhow::anyhow!("Unable to encrypt your master key")),
-    };
+    let master_key_encrypted =
+        master_key_result.map_err(|_| anyhow::anyhow!("Unable to encrypt your master key"))?;
 
     let header_new = Header {
         header_type: header.header_type,

--- a/dexios/src/subcommands/header.rs
+++ b/dexios/src/subcommands/header.rs
@@ -85,10 +85,8 @@ pub fn update_key(input: &str, key_old: &Key, key_new: &Key) -> Result<()> {
     })?;
 
     let mut master_key = [0u8; 32];
-
-    for (i, byte) in master_key_decrypted.iter().enumerate() {
-        master_key[i] = *byte;
-    }
+    let len = 32.min(master_key_decrypted.len());
+    master_key[..len].copy_from_slice(&master_key_decrypted[..len]);
 
     master_key_decrypted.zeroize();
     let master_key = Protected::new(master_key);

--- a/dexios/src/subcommands/list.rs
+++ b/dexios/src/subcommands/list.rs
@@ -1,4 +1,4 @@
-use anyhow::{Ok, Result};
+use anyhow::Result;
 
 use dexios_core::primitives::ALGORITHMS;
 


### PR DESCRIPTION
- renamed `domain/erase` to `domain/overwrite`. I'll add a canonical erase later, which will use overwrite itself.
- changed all `match` patterns that are used as `mar_err`
- added copy_from_slice instead of a manual copy loop