### PR TITLE
domain/erase: extract base logic of the erase command

### DIFF
--- a/dexios/src/domain/erase.rs
+++ b/dexios/src/domain/erase.rs
@@ -1,0 +1,53 @@
+use crate::domain;
+use std::io::{Read, Seek, Write};
+use std::path::Path;
+
+use domain::storage::Storage;
+
+#[derive(Debug)]
+pub enum Error {
+    OpenFile,
+    Overwrite(domain::overwrite::Error),
+    RemoveFile,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Error::*;
+        match self {
+            OpenFile => f.write_str("Unable to open file"),
+            Overwrite(inner) => write!(f, "Unable to overwrite file: {}", inner),
+            RemoveFile => f.write_str("Unable to write file"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+pub struct Request<P: AsRef<Path>> {
+    path: P,
+    passes: i32,
+}
+
+pub fn execute<RW: Read + Write + Seek, P: AsRef<Path>>(
+    stor: &impl Storage<RW>,
+    req: Request<P>,
+) -> Result<(), Error> {
+    // TODO: add logic for directories
+
+    let file = stor.write_file(req.path).map_err(|_| Error::OpenFile)?;
+    let buf_capacity = stor.file_len(&file).map_err(|_| Error::OpenFile)?;
+
+    domain::overwrite::execute(domain::overwrite::Request {
+        writer: file
+            .try_writer()
+            .expect("We're confident that we're in writing mode"),
+        buf_capacity,
+        passes: req.passes,
+    })
+    .map_err(Error::Overwrite)?;
+
+    stor.remove_file(&file).map_err(|_| Error::RemoveFile)?;
+
+    Ok(())
+}

--- a/dexios/src/domain/erase.rs
+++ b/dexios/src/domain/erase.rs
@@ -52,3 +52,41 @@ where
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::domain::storage::InMemoryStorage;
+
+    use super::*;
+
+    #[test]
+    fn should_erase_file() {
+        let stor = InMemoryStorage::default();
+        stor.add_hello_txt().unwrap();
+
+        let req = Request {
+            path: "hello.txt",
+            passes: 2,
+        };
+        match execute(&stor, req) {
+            Ok(_) => assert_eq!(stor.files.borrow().get(&PathBuf::from("hello.txt")), None),
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn should_not_open_file() {
+        let stor = InMemoryStorage::default();
+
+        let req = Request {
+            path: "hello.txt",
+            passes: 2,
+        };
+        match execute(&stor, req) {
+            Err(Error::OpenFile) => {}
+            _ => unreachable!(),
+        }
+    }
+}

--- a/dexios/src/domain/erase.rs
+++ b/dexios/src/domain/erase.rs
@@ -25,14 +25,15 @@ impl std::fmt::Display for Error {
 impl std::error::Error for Error {}
 
 pub struct Request<P: AsRef<Path>> {
-    path: P,
-    passes: i32,
+    pub path: P,
+    pub passes: i32,
 }
 
-pub fn execute<RW: Read + Write + Seek, P: AsRef<Path>>(
-    stor: &impl Storage<RW>,
-    req: Request<P>,
-) -> Result<(), Error> {
+pub fn execute<RW, P>(stor: &impl Storage<RW>, req: Request<P>) -> Result<(), Error>
+where
+    RW: Read + Write + Seek,
+    P: AsRef<Path>,
+{
     // TODO: add logic for directories
 
     let file = stor.write_file(req.path).map_err(|_| Error::OpenFile)?;

--- a/dexios/src/domain/erase.rs
+++ b/dexios/src/domain/erase.rs
@@ -17,7 +17,7 @@ impl std::fmt::Display for Error {
         match self {
             OpenFile => f.write_str("Unable to open file"),
             Overwrite(inner) => write!(f, "Unable to overwrite file: {}", inner),
-            RemoveFile => f.write_str("Unable to write file"),
+            RemoveFile => f.write_str("Unable to remove file"),
         }
     }
 }

--- a/dexios/src/domain/mod.rs
+++ b/dexios/src/domain/mod.rs
@@ -1,3 +1,4 @@
+pub mod erase;
 pub mod hash;
 pub mod hasher;
 pub mod overwrite;

--- a/dexios/src/domain/mod.rs
+++ b/dexios/src/domain/mod.rs
@@ -1,3 +1,4 @@
 pub mod hash;
 pub mod hasher;
 pub mod overwrite;
+pub mod storage;

--- a/dexios/src/domain/overwrite.rs
+++ b/dexios/src/domain/overwrite.rs
@@ -27,8 +27,8 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
-pub struct Request<W: Write + Seek> {
-    pub writer: RefCell<W>,
+pub struct Request<'a, W: Write + Seek> {
+    pub writer: &'a RefCell<W>,
     pub buf_capacity: usize,
     pub passes: i32,
 }
@@ -84,7 +84,7 @@ mod tests {
         let writer = Cursor::new(&mut buf);
 
         let req = Request {
-            writer: RefCell::new(writer),
+            writer: &RefCell::new(writer),
             buf_capacity: capacity,
             passes,
         };

--- a/dexios/src/domain/storage.rs
+++ b/dexios/src/domain/storage.rs
@@ -307,6 +307,17 @@ mod tests {
     }
 
     #[test]
+    fn should_throw_an_error_if_file_already_exist() {
+        let stor = InMemoryStorage::default();
+        stor.add_hello_txt().unwrap();
+
+        match stor.create_file("hello.txt") {
+            Err(Error::CreateFile) => {}
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
     fn should_not_open_file_to_read() {
         let stor = InMemoryStorage::default();
 

--- a/dexios/src/domain/storage.rs
+++ b/dexios/src/domain/storage.rs
@@ -127,6 +127,7 @@ impl Storage<io::Cursor<Vec<u8>>> for InMemoryStorage {
     fn flush_file(&self, file: File<io::Cursor<Vec<u8>>>) -> Result<(), Error> {
         let file_path = file.path();
         let writer = file.try_writer()?;
+        writer.borrow_mut().flush().map_err(|_| Error::FlushFile)?;
 
         let vec = writer.clone().into_inner().into_inner();
         let len = vec.len();

--- a/dexios/src/domain/storage.rs
+++ b/dexios/src/domain/storage.rs
@@ -1,0 +1,211 @@
+use std::cell::RefCell;
+use std::fs;
+use std::io::{Read, Seek, Write};
+use std::path::{Path, PathBuf};
+
+#[cfg(test)]
+use std::collections::HashMap;
+#[cfg(test)]
+use std::io;
+
+#[derive(Debug)]
+pub enum Error {
+    OpenFile,
+    RemoveFile,
+    WriteFile,
+    FlushFile,
+    FileAccess,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Error::*;
+        match self {
+            OpenFile => f.write_str("Unable to read file"),
+            WriteFile => f.write_str("Unable to write file"),
+            FlushFile => f.write_str("Unable to flush file"),
+            RemoveFile => f.write_str("Unable to remove file"),
+            FileAccess => f.write_str("Permission denied"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+pub trait Storage<RW>
+where
+    RW: Read + Write + Seek,
+{
+    fn open_file<P: AsRef<Path>>(&self, path: P) -> Result<File<RW>, Error>;
+    fn write_file<P: AsRef<Path>>(&self, path: P) -> Result<File<RW>, Error>;
+    fn flush_file(&self, file: File<RW>) -> Result<(), Error>;
+    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Error>;
+}
+
+pub struct FileStorage {}
+
+impl Storage<fs::File> for FileStorage {
+    fn open_file<P: AsRef<Path>>(&self, path: P) -> Result<File<fs::File>, Error> {
+        let path = path.as_ref().to_path_buf();
+        let file = fs::File::open(&path).map_err(|_| Error::OpenFile)?;
+
+        Ok(File::Read(ReadFile {
+            path,
+            reader: RefCell::new(file),
+        }))
+    }
+
+    fn write_file<P: AsRef<Path>>(&self, path: P) -> Result<File<fs::File>, Error> {
+        let path = path.as_ref().to_path_buf();
+        let file = fs::File::create(&path).map_err(|_| Error::WriteFile)?;
+
+        Ok(File::Write(WriteFile {
+            path,
+            writer: RefCell::new(file),
+        }))
+    }
+
+    fn flush_file(&self, file: File<fs::File>) -> Result<(), Error> {
+        file.try_writer()?
+            .borrow_mut()
+            .flush()
+            .map_err(|_| Error::FlushFile)
+    }
+
+    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+        fs::remove_file(path).map_err(|_| Error::RemoveFile)
+    }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+pub struct InMemoryStorage {
+    pub files: RefCell<HashMap<PathBuf, InMemoryFile>>,
+}
+
+#[cfg(test)]
+impl InMemoryStorage {
+    fn save_file(&self, path: PathBuf, file: InMemoryFile) -> Result<(), Error> {
+        self.files
+            .borrow_mut()
+            .insert(path, file)
+            .ok_or(Error::WriteFile)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+impl Storage<io::Cursor<Vec<u8>>> for InMemoryStorage {
+    fn open_file<P: AsRef<Path>>(&self, path: P) -> Result<File<io::Cursor<Vec<u8>>>, Error> {
+        let files = self.files.borrow();
+        let file = files.get(path.as_ref()).ok_or(Error::OpenFile)?;
+        let cursor = io::Cursor::new(file.buf.clone());
+
+        Ok(File::Read(ReadFile {
+            path: path.as_ref().to_path_buf(),
+            reader: RefCell::new(cursor),
+        }))
+    }
+
+    fn write_file<P: AsRef<Path>>(&self, path: P) -> Result<File<io::Cursor<Vec<u8>>>, Error> {
+        let file_path = path.as_ref().to_path_buf();
+        let file = InMemoryFile {
+            buf: vec![],
+            len: 0,
+        };
+        let cursor = io::Cursor::new(file.buf.clone());
+
+        self.save_file(file_path, file)?;
+
+        Ok(File::Read(ReadFile {
+            path: path.as_ref().to_path_buf(),
+            reader: RefCell::new(cursor),
+        }))
+    }
+
+    fn flush_file(&self, file: File<io::Cursor<Vec<u8>>>) -> Result<(), Error> {
+        let file_path = file.file_path();
+        let writer = file.try_writer()?;
+
+        let vec = writer.clone().into_inner().into_inner();
+        let len = vec.len();
+        let new_file = InMemoryFile { buf: vec, len };
+
+        self.save_file(file_path.to_path_buf(), new_file)?;
+
+        Ok(())
+    }
+
+    fn remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+        self.files
+            .borrow_mut()
+            .remove(path.as_ref())
+            .ok_or(Error::RemoveFile)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+pub struct InMemoryFile {
+    pub buf: Vec<u8>,
+    pub len: usize,
+}
+
+pub struct ReadFile<R>
+where
+    R: Read + Seek,
+{
+    path: PathBuf,
+    reader: RefCell<R>,
+}
+
+pub struct WriteFile<W>
+where
+    W: Write + Seek,
+{
+    path: PathBuf,
+    writer: RefCell<W>,
+}
+
+pub enum File<RW>
+where
+    RW: Read + Write + Seek,
+{
+    Read(ReadFile<RW>),
+    Write(WriteFile<RW>),
+    // TODO: Dir and Symlink?
+}
+
+impl<RW> File<RW>
+where
+    RW: Read + Write + Seek,
+{
+    pub fn file_path(&self) -> &Path {
+        match self {
+            File::Read(ReadFile { path, .. }) => path,
+            File::Write(WriteFile { path, .. }) => path,
+        }
+    }
+
+    pub fn try_reader(&self) -> Result<&RefCell<RW>, Error> {
+        match self {
+            File::Read(file) => Ok(&file.reader),
+            _ => Err(Error::FileAccess),
+        }
+    }
+
+    pub fn try_writer(&self) -> Result<&RefCell<RW>, Error> {
+        match self {
+            File::Write(file) => Ok(&file.writer),
+            _ => Err(Error::FileAccess),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn should_create_file() {}
+}

--- a/dexios/src/domain/storage.rs
+++ b/dexios/src/domain/storage.rs
@@ -136,9 +136,9 @@ impl Storage<io::Cursor<Vec<u8>>> for InMemoryStorage {
 
         self.save_file(file_path.clone(), file)?;
 
-        Ok(File::Read(ReadFile {
+        Ok(File::Write(WriteFile {
             path: file_path,
-            reader: RefCell::new(cursor),
+            writer: RefCell::new(cursor),
         }))
     }
 

--- a/dexios/src/subcommands/erase.rs
+++ b/dexios/src/subcommands/erase.rs
@@ -55,23 +55,16 @@ pub fn secure_erase(input: &str, passes: i32) -> Result<()> {
         input, passes
     ));
 
-    let file = File::create(input).with_context(|| format!("Unable to open file: {}", input))?;
-    let buf_capacity = file_meta.len() as usize;
+    // TODO: It is necessary to raise it to a higher level
+    let stor = domain::storage::FileStorage;
 
-    domain::overwrite::execute(domain::overwrite::Request {
-        writer: RefCell::new(BufWriter::new(file)),
-        buf_capacity,
-        passes,
-    })?;
-
-    let mut file = File::create(input).context("Unable to open the input file")?;
-    file.set_len(0)
-        .with_context(|| format!("Unable to truncate file: {}", input))?;
-    file.flush()
-        .with_context(|| format!("Unable to flush file: {}", input))?;
-    drop(file);
-
-    std::fs::remove_file(input).with_context(|| format!("Unable to remove file: {}", input))?;
+    domain::erase::execute(
+        &stor,
+        domain::erase::Request {
+            path: input,
+            passes,
+        },
+    )?;
 
     let duration = start_time.elapsed();
 

--- a/dexios/src/subcommands/erase.rs
+++ b/dexios/src/subcommands/erase.rs
@@ -1,12 +1,7 @@
 use crate::domain;
 use anyhow::{Context, Result};
 use paris::Logger;
-use std::{
-    cell::RefCell,
-    fs::File,
-    io::{BufWriter, Write},
-    time::Instant,
-};
+use std::{fs::File, time::Instant};
 
 use super::prompt::get_answer;
 


### PR DESCRIPTION
- [x] add file storage trait and two implementations (fs for main logic and in memory for tests).
- [x] extract base logic of the erase command
- [x] cover storage with unit tests
- [x] cover erase domain with unit tests