### PR TITLE
docker: add possibility to use cli via docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.62.0-slim-buster
+
+WORKDIR /app
+
+COPY Cargo.* ./
+COPY ./dexios ./dexios
+COPY ./dexios-core ./dexios-core
+
+RUN cargo build --bin dexios --release --locked \
+  && rm -rf ./dexios* Cargo.*
+
+ENTRYPOINT ["/app/target/release/dexios"]
+


### PR DESCRIPTION
Now anyone can use dexios using the following command

```sh
docker build -t dexios .
docker run --rm -it -v $PWD:/data dexios -e test.txt test.enc
```

@brxken128 you can build and publish to the docker hub, then the image name will look like `brxken128/dexios`.

Might solve the problem (#103 and possibly another) for Windows users