### PR TITLE
Depreciate Deoxys Encryption

### DIFF
--- a/.github/workflows/dexios-tests.yml
+++ b/.github/workflows/dexios-tests.yml
@@ -54,12 +54,6 @@ jobs:
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -eHyk keyfile --aead 2 100MB.bin 100MB.enc
     - name: Decrypt in stream mode (AES-256-GCM)
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -dHyk keyfile 100MB.enc 100MB.bin
-    - name: Generate test file
-      run: dd if=/dev/urandom of=100MB.bin bs=1M count=100
-    - name: Encrypt in stream mode (Deoxys-II-256)
-      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -eHyk keyfile --aead 3 100MB.bin 100MB.enc
-    - name: Decrypt in stream mode (Deoxys-II-256)
-      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -dHyk keyfile 100MB.enc 100MB.bin
   header-tests:
     needs: build
     runs-on: ubuntu-latest
@@ -160,12 +154,6 @@ jobs:
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -eHyk keyfile --aead 2 1GB.bin 1GB.enc
     - name: Decrypt 1GB file (AES-256-GCM)
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -dHyk keyfile 1GB.enc 1GB.bin
-    - name: Generate test file
-      run: dd if=/dev/urandom of=1GB.bin bs=1M count=1000
-    - name: Encrypt 1GB file (Deoxys-II-256)
-      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -eHyk keyfile --aead 3 1GB.bin 1GB.enc
-    - name: Decrypt 1GB file (Deoxys-II-256)
-      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -dHyk keyfile 1GB.enc 1GB.bin
   small-file:
     needs: build
     runs-on: ubuntu-latest
@@ -190,12 +178,6 @@ jobs:
     - name: Encrypt 1KB file (AES-256-GCM)
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -eHyk keyfile --aead 2 1KB.bin 1KB.enc
     - name: Decrypt 1KB file (AES-256-GCM)
-      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -dHyk keyfile 1KB.enc 1KB.bin
-    - name: Generate test file
-      run: dd if=/dev/urandom of=1KB.bin bs=1 count=1024
-    - name: Encrypt 1KB file (Deoxys-II-256)
-      run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -eHyk keyfile --aead 3 1KB.bin 1KB.enc
-    - name: Decrypt 1KB file (Deoxys-II-256)
       run: /home/runner/work/dexios/dexios/target/release/dexios/dexios -dHyk keyfile 1KB.enc 1KB.bin
   pack:
     needs: build

--- a/dexios-core/src/primitives.rs
+++ b/dexios-core/src/primitives.rs
@@ -9,7 +9,7 @@ pub const BLOCK_SIZE: usize = 1_048_576; // 1024*1024 bytes
 pub const SALT_LEN: usize = 16; // bytes
 
 /// This is an `enum` containing all AEADs supported by `dexios-core`
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Algorithm {
     Aes256Gcm,
     XChaCha20Poly1305,

--- a/dexios/src/global/parameters.rs
+++ b/dexios/src/global/parameters.rs
@@ -97,12 +97,20 @@ pub fn encrypt_additional_params(sub_matches: &ArgMatches) -> Result<Algorithm> 
         1
     };
 
-    if provided_aead < 1 || provided_aead > ALGORITHMS.len() {
-        Err(anyhow::anyhow!(
+    let algorithm = if provided_aead < 1 || provided_aead > ALGORITHMS.len() {
+        return Err(anyhow::anyhow!(
             "Invalid AEAD selected! Use \"dexios list aead\" to see all possible values."
         ))
     } else {
-        Ok(ALGORITHMS[provided_aead - 1]) // -1 to account for indexing starting at 0
+        ALGORITHMS[provided_aead - 1] // -1 to account for indexing starting at 0
+    };
+
+    if algorithm == Algorithm::DeoxysII256 { // explicitly disallow deoxys
+        return Err(anyhow::anyhow!(
+            "Invalid AEAD selected! Use \"dexios list aead\" to see all possible values."
+        ))
+    } else {
+        Ok(algorithm)
     }
 }
 

--- a/dexios/src/subcommands/list.rs
+++ b/dexios/src/subcommands/list.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use dexios_core::primitives::ALGORITHMS;
+use dexios_core::primitives::{ALGORITHMS, Algorithm};
 
 // this just lists values contained within arrays
 pub fn show_values(input: &str) -> Result<()> {
@@ -8,6 +8,9 @@ pub fn show_values(input: &str) -> Result<()> {
         "aead" => {
             println!("Here are all possible AEADs you can select:");
             for (i, algorithm) in ALGORITHMS.iter().enumerate() {
+                if algorithm == &Algorithm::DeoxysII256 { // this is temporary, until deoxys is improved upstream
+                    continue;
+                }
                 println!("{} => {}", (i + 1), algorithm);
             }
         }


### PR DESCRIPTION
This adds explicit disallowing of Deoxys for encryption, however decryption will still be supported.

This fixes #116.