### PR TITLE
core: use const fn instead of vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.cargo/
+
 /notes.md
 /dexios/CHANGELOG.md
 /target

--- a/dexios-core/src/primitives.rs
+++ b/dexios-core/src/primitives.rs
@@ -17,15 +17,21 @@ pub enum Algorithm {
     DeoxysII256,
 }
 
-#[cfg(feature = "deoxys-ii-256")]
-const ALGORITHMS_LEN: usize = 3;
-#[cfg(not(feature = "deoxys-ii-256"))]
-const ALGORITHMS_LEN: usize = 2;
+#[allow(clippy::unnecessary_operation)] // 🚫 we cannot use cfg(feature) with expressions yet
+const fn algorithm_len() -> usize {
+    #[allow(unused_mut)]
+    let mut len: usize = 2;
+    #[cfg(feature = "deoxys-ii-256")]
+    {
+        len += 1
+    };
+    len
+}
 
 /// This is an array containing all AEADs supported by `dexios-core`.
 ///
 /// It can be used by and end-user application to show a list of AEADs that they may use
-pub static ALGORITHMS: [Algorithm; ALGORITHMS_LEN] = [
+pub static ALGORITHMS: [Algorithm; algorithm_len()] = [
     Algorithm::XChaCha20Poly1305,
     Algorithm::Aes256Gcm,
     #[cfg(feature = "deoxys-ii-256")]

--- a/dexios-core/src/primitives.rs
+++ b/dexios-core/src/primitives.rs
@@ -17,12 +17,10 @@ pub enum Algorithm {
     DeoxysII256,
 }
 
-#[allow(clippy::unnecessary_operation)] // 🚫 we cannot use cfg(feature) with expressions yet
 const fn algorithm_len() -> usize {
     #[allow(unused_mut)]
     let mut len: usize = 2;
-    #[cfg(feature = "deoxys-ii-256")]
-    {
+    if cfg!(feature = "deoxys-ii-256") {
         len += 1
     };
     len


### PR DESCRIPTION
This will be better than the previous solution, because we can add more features to the algorithms without headache!

let's imagine that we have 2 features... how should we implement them?

```rust
#[cfg(not(all(feature = "1", feature = "2")))]
const LEN = 2;

#[cfg(any(all(feature = "1", not(feature = "2")), all(not(feature = "1"), feature = "2"))))]
const LEN = 3;

#[cfg(all(feature = "1", feature = "2"))]
const LEN = 4;
```

what about 3 features?))

another way is

```rust
#[cfg(features = "1")]
const DEOXYS_ENABLED: usize = 1;

#[cfg(not(features = "1"))]
const DEOXYS_ENABLED: usize = 0;

#[cfg(feature = "2")]
const ANOTHER_ENABLED: usize = 1;

#[cfg(not(feature = "2"))]
const ANOTHER_ENABLED: usize = 0;

const LEN: usize = 2 + DEOXYS_ENABLED + ANOTHER_ENABLED;
```

Better! Easy to maintain, but a lot of unnecessary code