### PR TITLE
cli: add stdin support for the keyfile param

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+/target
+/assets
+/.git*
+
+*.md
+*.nix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "clap",
- "dexios-core 1.1.1 (git+https://github.com/pleshevskiy/dexios?branch=features)",
+ "dexios-core",
  "hex",
  "paris",
  "rand",
@@ -312,23 +312,6 @@ dependencies = [
 [[package]]
 name = "dexios-core"
 version = "1.1.1"
-dependencies = [
- "aead",
- "aes-gcm",
- "anyhow",
- "argon2",
- "balloon-hash",
- "blake3",
- "chacha20poly1305",
- "deoxys",
- "rand",
- "zeroize",
-]
-
-[[package]]
-name = "dexios-core"
-version = "1.1.1"
-source = "git+https://github.com/pleshevskiy/dexios?branch=features#564c9d48b27e81babe4fad949a902824b012f8b5"
 dependencies = [
  "aead",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,3 @@ members = [
     "dexios",
     "dexios-core",
 ]
-
-[patch.crates-io]
-# we should update core version to use features correctly
-dexios-core = { git = "https://github.com/pleshevskiy/dexios", branch = "features" }
-# dexios-core = { git = "https://github.com/brxken128/dexios", branch = "master" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,16 @@ ARG features=""
 
 WORKDIR /app
 
-COPY Cargo.lock ./
-COPY ./dexios ./
+COPY Cargo.* ./
+COPY ./dexios ./dexios
+COPY ./dexios-core ./dexios-core
 
-RUN cargo build --bin dexios --release --locked ${features:+--features=${features}} \
+RUN cargo install --bin dexios --path ./dexios ${features:+--features=${features}} \
   && rm -rf ./dexios* Cargo.*
 
 VOLUME ["/data"]
 
 WORKDIR /data
 
-ENTRYPOINT ["/app/target/release/dexios"]
+ENTRYPOINT ["/usr/local/cargo/bin/dexios"]
 

--- a/dexios-core/src/protected.rs
+++ b/dexios-core/src/protected.rs
@@ -36,6 +36,17 @@ where
     data: T,
 }
 
+impl<T> std::ops::Deref for Protected<T>
+where
+    T: Zeroize,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
 impl<T> Protected<T>
 where
     T: Zeroize,

--- a/dexios/Cargo.toml
+++ b/dexios/Cargo.toml
@@ -24,9 +24,7 @@ deoxys-ii-256 = ["dexios-core/deoxys-ii-256"]
 blake3 = "1.3.1"
 rand = "0.8.5"
 
-# TODO(brxken128): update crate version
-# Note: we cannot use the "path", because default features will not be disabled
-dexios-core = { version = "1.1.1", default-features = false }
+dexios-core = { path = "../dexios-core", version = "1.1.1", default-features = false }
 
 walkdir = "2.3.2"
 
@@ -40,8 +38,3 @@ zip = { version = "0.6.2", default-features = false, features = ["zstd"] }
 
 [target.'cfg(unix)'.dependencies]
 termion = "1.5.6"
-
-# Note: this section uses to build docker
-[patch.crates-io]
-dexios-core = { git = "https://github.com/pleshevskiy/dexios", branch = "features" }
-# dexios-core = { git = "https://github.com/brxken128/dexios", branch = "master" }

--- a/dexios/src/file.rs
+++ b/dexios/src/file.rs
@@ -1,12 +1,12 @@
 use anyhow::{Context, Ok, Result};
 use dexios_core::protected::Protected;
-use std::{fs::File, io::Read};
+use std::io::Read;
 
 // this takes the name/relative path of a file, and returns the bytes in a "protected" wrapper
-pub fn get_bytes(name: &str) -> Result<Protected<Vec<u8>>> {
-    let mut file = File::open(name).with_context(|| format!("Unable to open file: {}", name))?;
+pub fn get_bytes<R: Read>(reader: &mut R) -> Result<Protected<Vec<u8>>> {
     let mut data = Vec::new();
-    file.read_to_end(&mut data)
-        .with_context(|| format!("Unable to read file: {}", name))?;
+    reader
+        .read_to_end(&mut data)
+        .context("Unable to read data")?;
     Ok(Protected::new(data))
 }


### PR DESCRIPTION
A small change from me. I'm currently using this program roughly as shown in the following example:

```sh
DEXIOS_KEY=$(pass show dexios/finance) dexios -py business business.enc 
```

This changes make it possible to use the password manager directly

```sh
pass show dexios/finance | dexios -pyk - business business.enc
```

or read keyfile and pipe to program

```sh
cat mykeyfile | dexios -pyk - business business.enc
```