### PR TITLE
cli/decrypt: fix matching autogenerate arg

### DIFF
--- a/dexios/src/global/parameters.rs
+++ b/dexios/src/global/parameters.rs
@@ -31,7 +31,7 @@ pub fn parameter_handler(sub_matches: &ArgMatches) -> Result<CryptoParams> {
         )
     } else if std::env::var("DEXIOS_KEY").is_ok() {
         Key::Env
-    } else if sub_matches.is_present("autogenerate") {
+    } else if let Ok(true) = sub_matches.try_contains_id("autogenerate") {
         Key::Generate
     } else {
         Key::User


### PR DESCRIPTION
The clap update seems to have broken our decrypt command.

```
➜  dexios git:(master) ✗ cargo run -- decrypt flake.enc flake.orig
thread 'main' panicked at '`autogenerate` is not an id of an argument or a group.
Make sure you're using the name of the argument itself and not the name of short or long flags.', dexios/src/global/parameters.rs:34:27
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```