### PR TITLE
Migrate to `ThreadRng` from `StdRng`

### DIFF
--- a/.github/workflows/cargo-build.yml
+++ b/.github/workflows/cargo-build.yml
@@ -48,6 +48,19 @@ jobs:
         command: check
         args: --release
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+    - name: Test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --release
+
   build-linux:
     runs-on: ubuntu-latest
     steps:

--- a/dexios-core/src/key.rs
+++ b/dexios-core/src/key.rs
@@ -16,25 +16,6 @@ use super::primitives::SALT_LEN;
 use super::header::HeaderVersion;
 use super::protected::Protected;
 use anyhow::Result;
-use rand::prelude::ThreadRng;
-use rand::RngCore;
-
-/// This generates a salt, of the specified `SALT_LEN`
-///
-/// This salt can be directly passed to `argon2id_hash()` or `balloon_hash()`
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// let salt = gen_salt();
-/// ```
-///
-#[must_use]
-pub fn gen_salt() -> [u8; SALT_LEN] {
-    let mut salt = [0u8; SALT_LEN];
-    ThreadRng::default().fill_bytes(&mut salt);
-    salt
-}
 
 /// This handles `argon2id` hashing of a raw key
 ///

--- a/dexios-core/src/key.rs
+++ b/dexios-core/src/key.rs
@@ -16,9 +16,8 @@ use super::primitives::SALT_LEN;
 use super::header::HeaderVersion;
 use super::protected::Protected;
 use anyhow::Result;
-use rand::prelude::StdRng;
+use rand::prelude::ThreadRng;
 use rand::RngCore;
-use rand::SeedableRng;
 
 /// This generates a salt, of the specified `SALT_LEN`
 ///
@@ -33,7 +32,7 @@ use rand::SeedableRng;
 #[must_use]
 pub fn gen_salt() -> [u8; SALT_LEN] {
     let mut salt = [0u8; SALT_LEN];
-    StdRng::from_entropy().fill_bytes(&mut salt);
+    ThreadRng::default().fill_bytes(&mut salt);
     salt
 }
 

--- a/dexios-core/src/primitives.rs
+++ b/dexios-core/src/primitives.rs
@@ -1,7 +1,5 @@
 //! This module contains all cryptographic primitives used by `dexios-core`
 
-use rand::prelude::ThreadRng;
-
 /// This is the streaming block size
 ///
 /// NOTE: Stream mode can be used to encrypt files less than this size, provided the implementation is correct
@@ -80,7 +78,7 @@ impl std::fmt::Display for Mode {
 ///
 #[must_use]
 pub fn gen_nonce(algorithm: &Algorithm, mode: &Mode) -> Vec<u8> {
-    use rand::RngCore;
+    use rand::{RngCore, prelude::ThreadRng};
     let nonce_len = get_nonce_len(algorithm, mode);
     let mut nonce = vec![0u8; nonce_len];
     ThreadRng::default().fill_bytes(&mut nonce);

--- a/dexios-core/src/primitives.rs
+++ b/dexios-core/src/primitives.rs
@@ -1,5 +1,7 @@
 //! This module contains all cryptographic primitives used by `dexios-core`
 
+use rand::prelude::ThreadRng;
+
 /// This is the streaming block size
 ///
 /// NOTE: Stream mode can be used to encrypt files less than this size, provided the implementation is correct
@@ -78,10 +80,10 @@ impl std::fmt::Display for Mode {
 ///
 #[must_use]
 pub fn gen_nonce(algorithm: &Algorithm, mode: &Mode) -> Vec<u8> {
-    use rand::{prelude::StdRng, RngCore, SeedableRng};
+    use rand::RngCore;
     let nonce_len = get_nonce_len(algorithm, mode);
     let mut nonce = vec![0u8; nonce_len];
-    StdRng::from_entropy().fill_bytes(&mut nonce);
+    ThreadRng::default().fill_bytes(&mut nonce);
     nonce
 }
 

--- a/dexios-core/src/primitives.rs
+++ b/dexios-core/src/primitives.rs
@@ -5,6 +5,8 @@
 /// NOTE: Stream mode can be used to encrypt files less than this size, provided the implementation is correct
 pub const BLOCK_SIZE: usize = 1_048_576; // 1024*1024 bytes
 
+use crate::protected::Protected;
+
 /// This is the length of the salt used for password hashing
 pub const SALT_LEN: usize = 16; // bytes
 
@@ -66,6 +68,8 @@ impl std::fmt::Display for Mode {
     }
 }
 
+use rand::{RngCore, prelude::ThreadRng};
+
 /// This can be used to generate a nonce for encryption
 /// It requires both the algorithm and the mode, so it can correctly determine the nonce length
 /// This nonce can be passed directly to `EncryptionStreams::initialize()`
@@ -78,7 +82,6 @@ impl std::fmt::Display for Mode {
 ///
 #[must_use]
 pub fn gen_nonce(algorithm: &Algorithm, mode: &Mode) -> Vec<u8> {
-    use rand::{RngCore, prelude::ThreadRng};
     let nonce_len = get_nonce_len(algorithm, mode);
     let mut nonce = vec![0u8; nonce_len];
     ThreadRng::default().fill_bytes(&mut nonce);
@@ -98,4 +101,37 @@ pub fn get_nonce_len(algorithm: &Algorithm, mode: &Mode) -> usize {
     }
 
     nonce_len
+}
+
+/// This can be used to generate a master key for encryption
+/// It uses `ThreadRng` to securely generate 32 completely random bytes, with extra protection from some side-channel attacks
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// let master_key = gen_master_key();
+/// ```
+///
+pub fn gen_master_key() -> Protected<[u8; 32]> {
+    let mut master_key = [0u8; 32];
+    ThreadRng::default().fill_bytes(&mut master_key);
+    Protected::new(master_key)
+}
+
+
+/// This generates a salt, of the specified `SALT_LEN`
+///
+/// This salt can be directly passed to `argon2id_hash()` or `balloon_hash()`
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// let salt = gen_salt();
+/// ```
+///
+#[must_use]
+pub fn gen_salt() -> [u8; SALT_LEN] {
+    let mut salt = [0u8; SALT_LEN];
+    ThreadRng::default().fill_bytes(&mut salt);
+    salt
 }

--- a/dexios/src/utils.rs
+++ b/dexios/src/utils.rs
@@ -38,17 +38,8 @@ pub use test::gen_nonce;
 pub use test::gen_salt;
 
 #[cfg(not(test))]
-pub use dexios_core::key::gen_salt;
+pub use dexios_core::primitives::gen_salt;
 #[cfg(not(test))]
 pub use dexios_core::primitives::gen_nonce;
-
 #[cfg(not(test))]
-use dexios_core::protected::Protected;
-#[cfg(not(test))]
-use rand::{prelude::StdRng, RngCore, SeedableRng};
-#[cfg(not(test))]
-pub fn gen_master_key() -> Protected<[u8; 32]> {
-    let mut master_key = [0u8; 32];
-    StdRng::from_entropy().fill_bytes(&mut master_key);
-    Protected::new(master_key)
-}
+pub use dexios_core::primitives::gen_master_key;


### PR DESCRIPTION
Although the changes are pretty trivial, this should provide additional protection from certain side-channel attacks.

I implemented this for things that need it the most: the salt, nonce, and master key.

The discussion regarding this can be found in #135.

`gen_salt()` and `gen_master_key()` were also moved into `primitives.rs`, to keep things uniform and in one place.