### PR TITLE
[FEATURE] Add a progress spinner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "terminal_size",
+ "winapi",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +334,7 @@ dependencies = [
  "blake3",
  "chacha20poly1305",
  "deoxys",
+ "indicatif",
  "rand",
  "zeroize",
 ]
@@ -335,6 +349,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "generic-array"
@@ -399,6 +419,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,10 +440,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "numtoa"
@@ -532,6 +576,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +618,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/dexios-core/Cargo.toml
+++ b/dexios-core/Cargo.toml
@@ -18,8 +18,9 @@ license = "BSD-2-Clause"
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["deoxys-ii-256"]
+default = ["deoxys-ii-256", "visual"]
 deoxys-ii-256 = ["deoxys"]
+visual = ["indicatif"]
 
 [dependencies]
 # for errors, only temporary
@@ -41,3 +42,5 @@ blake3 = { version = "1.3.1", features = ["traits-preview"] }
 
 # for generating random bytes
 rand = "0.8.5"
+
+indicatif = { version = "0.16.2", optional = true }

--- a/dexios-core/src/lib.rs
+++ b/dexios-core/src/lib.rs
@@ -43,3 +43,6 @@ pub mod protected;
 pub mod stream;
 pub use aead::Payload;
 pub use zeroize::Zeroize;
+
+#[cfg(feature = "visual")]
+pub mod visual;

--- a/dexios-core/src/stream.rs
+++ b/dexios-core/src/stream.rs
@@ -193,6 +193,9 @@ impl EncryptionStreams {
         writer: &mut impl Write,
         aad: &[u8],
     ) -> anyhow::Result<()> {
+        #[cfg(feature = "visual")]
+        let pb = crate::visual::create_spinner();
+
         let mut read_buffer = vec![0u8; BLOCK_SIZE].into_boxed_slice();
         loop {
             let read_count = reader
@@ -233,6 +236,9 @@ impl EncryptionStreams {
         }
         read_buffer.zeroize();
         writer.flush().context("Unable to flush the output")?;
+
+        #[cfg(feature = "visual")]
+        pb.finish_and_clear();
 
         Ok(())
     }
@@ -358,6 +364,9 @@ impl DecryptionStreams {
         writer: &mut impl Write,
         aad: &[u8],
     ) -> anyhow::Result<()> {
+        #[cfg(feature = "visual")]
+        let pb = crate::visual::create_spinner();
+
         let mut buffer = vec![0u8; BLOCK_SIZE + 16].into_boxed_slice();
         loop {
             let read_count = reader.read(&mut buffer)?;
@@ -397,6 +406,9 @@ impl DecryptionStreams {
         }
 
         writer.flush().context("Unable to flush the output")?;
+
+        #[cfg(feature = "visual")]
+        pb.finish_and_clear();
 
         Ok(())
     }

--- a/dexios-core/src/visual.rs
+++ b/dexios-core/src/visual.rs
@@ -1,0 +1,12 @@
+#[cfg(feature = "visual")]
+use indicatif::{ProgressBar, ProgressStyle};
+
+#[cfg(feature = "visual")]
+pub fn create_spinner() -> ProgressBar {
+
+    let pb = ProgressBar::new_spinner();
+    pb.enable_steady_tick(120);
+    pb.set_style(ProgressStyle::default_spinner().template("{spinner:.cyan}"));
+
+    pb
+}

--- a/dexios-core/src/visual.rs
+++ b/dexios-core/src/visual.rs
@@ -3,7 +3,6 @@ use indicatif::{ProgressBar, ProgressStyle};
 
 #[cfg(feature = "visual")]
 pub fn create_spinner() -> ProgressBar {
-
     let pb = ProgressBar::new_spinner();
     pb.enable_steady_tick(120);
     pb.set_style(ProgressStyle::default_spinner().template("{spinner:.cyan}"));

--- a/dexios/Cargo.toml
+++ b/dexios/Cargo.toml
@@ -24,7 +24,7 @@ deoxys-ii-256 = ["dexios-core/deoxys-ii-256"]
 blake3 = "1.3.1"
 rand = "0.8.5"
 
-dexios-core = { path = "../dexios-core", version = "1.1.1", default-features = false }
+dexios-core = { path = "../dexios-core", version = "1.1.1", default-features = false, features = ["visual"] }
 
 walkdir = "2.3.2"
 


### PR DESCRIPTION
Due to the design of our current codebase, a progress *bar* would be quite unfeasible as we'd need to get and pass the file size down a multitude of functions. I like how our codebase stands currently, and I don't think this one feature warrants that amount of effort/refactoring.

With that, I've decided to implement a progress *spinner*. It's not as descriptive as a bar, but at least it lets the user know that things are still happening. I feel like this is a good compromise between the two.

This is related to #102.

(despite it not being a progress bar, I think it adds a nice touch for larger files/slow computers)

This also adds the `visual` feature to dexios-core, and that will pull in `indicatif` and display the spinner on stream encrypt/decrypt automatically (when the `encrypt/decrypt_file()` functions are used).