### PR TITLE
cli/decrypt: remove the tragic copy-paste error

### DIFF
--- a/dexios/src/subcommands/decrypt.rs
+++ b/dexios/src/subcommands/decrypt.rs
@@ -36,13 +36,7 @@ pub fn stream_mode(input: &str, output: &str, params: &CryptoParams) -> Result<(
     let input_file = stor.read_file(input)?;
     let header_file = match &params.header_location {
         HeaderLocation::Embedded => None,
-        HeaderLocation::Detached(path) => {
-            if !overwrite_check(path, params.skip)? {
-                exit(0);
-            }
-
-            Some(stor.read_file(path)?)
-        }
+        HeaderLocation::Detached(path) => Some(stor.read_file(path)?),
     };
 
     let raw_key = params.key.get_secret(&PasswordState::Direct)?;


### PR DESCRIPTION
It wasn't in [original](https://github.com/brxken128/dexios/pull/140/files#diff-34f6e48baa077b22449fa179834d96884d5854c2b280fc6676e9152424e887d3L145). Seems that I took this from the encrypt command)