### PR TITLE
cli/pack: add possibility to pack many files

### DIFF
--- a/dexios/src/cli.rs
+++ b/dexios/src/cli.rs
@@ -194,6 +194,7 @@ pub fn get_matches() -> clap::ArgMatches {
                 Arg::new("input")
                     .value_name("input")
                     .takes_value(true)
+                    .multiple_values(true)
                     .required(true)
                     .help("The directory to encrypt"),
             )

--- a/dexios/src/cli.rs
+++ b/dexios/src/cli.rs
@@ -191,19 +191,19 @@ pub fn get_matches() -> clap::ArgMatches {
             .about("Pack and encrypt an entire directory")
             .short_flag('p')
             .arg(
+                Arg::new("output")
+                    .value_name("output")
+                    .takes_value(true)
+                    .required(true)
+                    .help("The output file"),
+            )
+            .arg(
                 Arg::new("input")
                     .value_name("input")
                     .takes_value(true)
                     .multiple_values(true)
                     .required(true)
                     .help("The directory to encrypt"),
-            )
-            .arg(
-                Arg::new("output")
-                    .value_name("output")
-                    .takes_value(true)
-                    .required(true)
-                    .help("The output file"),
             )
             .arg(
                 Arg::new("erase")

--- a/dexios/src/global/parameters.rs
+++ b/dexios/src/global/parameters.rs
@@ -13,6 +13,16 @@ use dexios_core::primitives::ALGORITHMS;
 
 use super::states::{Compression, DirectoryMode, Key, PrintMode};
 
+pub fn get_params(name: &str, sub_matches: &ArgMatches) -> Result<Vec<String>> {
+    let values = sub_matches
+        .get_many::<String>(name)
+        .with_context(|| format!("No {} provided", name))?
+        .into_iter()
+        .map(String::from)
+        .collect();
+    Ok(values)
+}
+
 pub fn get_param(name: &str, sub_matches: &ArgMatches) -> Result<String> {
     let value = sub_matches
         .value_of(name)

--- a/dexios/src/subcommands.rs
+++ b/dexios/src/subcommands.rs
@@ -5,7 +5,7 @@ use clap::ArgMatches;
 // it gets params and sends them to the appropriate functions
 
 use crate::global::parameters::{
-    encrypt_additional_params, erase_params, get_param, pack_params, parameter_handler,
+    encrypt_additional_params, erase_params, get_param, get_params, pack_params, parameter_handler,
 };
 
 pub mod decrypt;
@@ -55,7 +55,7 @@ pub fn pack(sub_matches: &ArgMatches) -> Result<()> {
     let algorithm = encrypt_additional_params(sub_matches)?;
 
     pack::execute(pack::Request {
-        input_file: &get_param("input", sub_matches)?,
+        input_file: &get_params("input", sub_matches)?,
         output_file: &get_param("output", sub_matches)?,
         pack_params,
         crypto_params,


### PR DESCRIPTION
Some improvement from me... I currently have the following makefile:

```
pack:
	$(MAKE) DEXIOS_KEY=$$(pass show dexios/business_documents) pack-unchecked

pack-unchecked:
	dexios -py companies companies.enc
	dexios -py my_contracts my_contracts.enc
	dexios -py my_courses my_courses.enc
	dexios -py nalog nalog.enc
	dexios -py assets assets.enc

unpack:
	$(MAKE) DEXIOS_KEY=$$(pass show dexios/business_documents) unpack-unchecked

unpack-unchecked:
	dexios -uy companies.enc .
	dexios -uy my_contracts.enc .
	dexios -uy my_courses.enc .
	dexios -uy nalog.enc .
	dexios -uy assets.enc .
```

these changes allow me to make things easier!

```
pack:
	pass show dexios/business_documents | dexios -pyk - companies my_contracts my_courses nalog assets all.enc

unpack:
	pass show dexios/business_documents | dexios -uyk - all.enc .
```