### PR TITLE
[KEY] Add `init` function

### DIFF
--- a/dexios/src/global/states.rs
+++ b/dexios/src/global/states.rs
@@ -4,6 +4,7 @@
 // some enums are used purely by dexios to handle things (e.g. detached header files)
 
 use anyhow::{Context, Result};
+use clap::ArgMatches;
 use dexios_core::protected::Protected;
 use paris::warn;
 
@@ -114,6 +115,28 @@ impl Key {
             Err(anyhow::anyhow!("The specified key is empty!"))
         } else {
             Ok(secret)
+        }
+    }
+
+    pub fn init(arg_matches: &ArgMatches, params: &KeyParams) -> Self {
+        todo!()
+    }
+}
+
+pub struct KeyParams {
+    pub password: bool,
+    pub env: bool,
+    pub auto: bool,
+    pub keyfile: bool,
+}
+
+impl KeyParams {
+    pub fn default_validate() -> Self {
+        KeyParams {
+            password: true,
+            env: true,
+            auto: true,
+            keyfile: true,
         }
     }
 }

--- a/dexios/src/global/states.rs
+++ b/dexios/src/global/states.rs
@@ -118,21 +118,26 @@ impl Key {
         }
     }
 
-    pub fn init(sub_matches: &ArgMatches, params: KeyParams) -> Result<Self> {
-        let key = if sub_matches.is_present("keyfile") && params.keyfile {
+    pub fn init(
+        sub_matches: &ArgMatches,
+        params: KeyParams,
+        keyfile_descriptor: &str,
+    ) -> Result<Self> {
+        let key = if sub_matches.is_present(keyfile_descriptor) && params.keyfile {
             Key::Keyfile(
                 sub_matches
-                    .value_of("keyfile")
+                    .value_of(keyfile_descriptor)
                     .context("No keyfile/invalid text provided")?
                     .to_string(),
             )
         } else if std::env::var("DEXIOS_KEY").is_ok() && params.env {
             Key::Env
-        } else if let (Ok(true), true) =
-            (sub_matches.try_contains_id("autogenerate"), params.generate)
-        {
+        } else if let (Ok(true), true) = (
+            sub_matches.try_contains_id("autogenerate"),
+            params.autogenerate,
+        ) {
             Key::Generate
-        } else if params.password {
+        } else if params.user {
             Key::User
         } else {
             return Err(anyhow::anyhow!(
@@ -145,18 +150,18 @@ impl Key {
 }
 
 pub struct KeyParams {
-    pub password: bool,
+    pub user: bool,
     pub env: bool,
-    pub generate: bool,
+    pub autogenerate: bool,
     pub keyfile: bool,
 }
 
 impl KeyParams {
     pub fn default() -> Self {
         KeyParams {
-            password: true,
+            user: true,
             env: true,
-            generate: true,
+            autogenerate: true,
             keyfile: true,
         }
     }

--- a/dexios/src/main.rs
+++ b/dexios/src/main.rs
@@ -4,6 +4,8 @@ use global::parameters::key_manipulation_params;
 use global::parameters::skipmode;
 use subcommands::list::show_values;
 
+use crate::global::states::KeyParams;
+
 mod cli;
 mod domain;
 mod file;
@@ -105,26 +107,10 @@ fn main() -> Result<()> {
                 )?;
             }
             Some("del") => {
-                // TODO(brxken128): unify `Key` creation with one function
                 use crate::global::states::Key;
-                use anyhow::Context;
 
                 let sub_matches_del_key = sub_matches.subcommand_matches("del").unwrap();
-
-                let key = if sub_matches_del_key.is_present("keyfile") {
-                    Key::Keyfile(
-                        sub_matches_del_key
-                            .value_of("keyfile")
-                            .context("No keyfile/invalid text provided")?
-                            .to_string(),
-                    )
-                } else if std::env::var("DEXIOS_KEY").is_ok() {
-                    Key::Env
-                } else if let Ok(true) = sub_matches_del_key.try_contains_id("autogenerate") {
-                    Key::Generate
-                } else {
-                    Key::User
-                };
+                let key = Key::init(sub_matches_del_key, KeyParams::default(), "keyfile")?;
 
                 subcommands::header_key::del_key(&get_param("input", sub_matches_del_key)?, &key)?;
             }


### PR DESCRIPTION
This closes #163 and cleans up the codebase a lot.

I decided to require the specification of `"keyfile"`, as the key manipulation functions need alternate descriptors (`"keyfile-old"` and `"keyfile-new"`).