### PR TITLE
[CLIPPY] Implement `clippy` lints

### DIFF
--- a/dexios-core/src/header.rs
+++ b/dexios-core/src/header.rs
@@ -663,7 +663,12 @@ impl Header {
                 header_bytes.extend_from_slice(&tag.algorithm);
                 header_bytes.extend_from_slice(&tag.mode);
                 header_bytes.extend_from_slice(
-                    &self.salt.unwrap_or(self.keyslots.as_ref().unwrap()[0].salt),
+                    &self.salt.unwrap_or(
+                        self.keyslots.as_ref().ok_or_else(|| {
+                            anyhow::anyhow!("Cannot find a salt within the keyslot/header.")
+                        })?[0]
+                            .salt,
+                    ),
                 );
                 header_bytes.extend_from_slice(&self.nonce);
                 header_bytes.extend_from_slice(&padding);

--- a/dexios-core/src/key.rs
+++ b/dexios-core/src/key.rs
@@ -131,6 +131,7 @@ pub fn balloon_hash(
     Ok(Protected::new(key))
 }
 
+#[allow(clippy::module_name_repetitions)]
 pub fn decrypt_master_key(
     raw_key: Protected<Vec<u8>>,
     header: &Header,

--- a/dexios-core/src/key.rs
+++ b/dexios-core/src/key.rs
@@ -148,7 +148,7 @@ pub fn decrypt_master_key(
             let cipher = Ciphers::initialize(key, &header.header_type.algorithm)?;
             cipher
                 .decrypt(&keyslot.nonce, keyslot.encrypted_key.as_slice())
-                .map(vec_to_arr)
+                .map(|master_key| vec_to_arr(&master_key))
                 .map(Protected::new)
                 .map_err(|_| anyhow::anyhow!("Cannot decrypt master key"))
         }
@@ -164,7 +164,7 @@ pub fn decrypt_master_key(
                     let cipher = Ciphers::initialize(key, &header.header_type.algorithm).ok()?;
                     cipher
                         .decrypt(&keyslot.nonce, keyslot.encrypted_key.as_slice())
-                        .map(vec_to_arr)
+                        .map(|master_key| vec_to_arr(&master_key))
                         .map(Protected::new)
                         .ok()
                 })
@@ -174,7 +174,7 @@ pub fn decrypt_master_key(
 }
 
 // TODO: choose better place for this util
-pub fn vec_to_arr<const N: usize>(master_key_vec: Vec<u8>) -> [u8; N] {
+pub fn vec_to_arr<const N: usize>(master_key_vec: &[u8]) -> [u8; N] {
     let mut master_key = [0u8; N];
     let len = N.min(master_key_vec.len());
     master_key[..len].copy_from_slice(&master_key_vec[..len]);

--- a/dexios-core/src/key.rs
+++ b/dexios-core/src/key.rs
@@ -174,6 +174,7 @@ pub fn decrypt_master_key(
 }
 
 // TODO: choose better place for this util
+#[must_use]
 pub fn vec_to_arr<const N: usize>(master_key_vec: &[u8]) -> [u8; N] {
     let mut master_key = [0u8; N];
     let len = N.min(master_key_vec.len());

--- a/dexios/src/subcommands/header_key.rs
+++ b/dexios/src/subcommands/header_key.rs
@@ -97,7 +97,7 @@ pub fn change_key(input: &str, key_old: &Key, key_new: &Key) -> Result<()> {
                 )
             })?;
 
-            let master_key = Protected::new(vec_to_arr::<MASTER_KEY_LEN>(master_key_decrypted));
+            let master_key = Protected::new(vec_to_arr::<MASTER_KEY_LEN>(&master_key_decrypted));
 
             drop(cipher);
 
@@ -223,7 +223,7 @@ pub fn change_key(input: &str, key_old: &Key, key_new: &Key) -> Result<()> {
             let master_key_encrypted = master_key_result
                 .map_err(|_| anyhow::anyhow!("Unable to encrypt your master key"))?;
 
-            let master_key_encrypted_array = vec_to_arr(master_key_encrypted);
+            let master_key_encrypted_array = vec_to_arr(&master_key_encrypted);
 
             // TODO(brxken128): allow using argon2id/balloon/inherit
             keyslots[index] = Keyslot {
@@ -319,7 +319,7 @@ pub fn add_key(input: &str, key_old: &Key, key_new: &Key) -> Result<()> {
             let master_key_encrypted = master_key_result
                 .map_err(|_| anyhow::anyhow!("Unable to encrypt your master key"))?;
 
-            let master_key_encrypted_array = vec_to_arr(master_key_encrypted);
+            let master_key_encrypted_array = vec_to_arr(&master_key_encrypted);
 
             // TODO(brxken128): allow using argon2id/balloon/inherit
             let keyslot_new = Keyslot {


### PR DESCRIPTION
This implements everything mentioned by the following command:

`cargo clippy --all -- -W clippy::pedantic -W clippy::correctness -W clippy::perf -W clippy::style -W clippy::suspicious -W clippy::complexity -D warnings`.

I have not resolved the doc errors, as they're likely to change and not currently a priority.