### PR TITLE
[CRATE] Adds a base layout for the `domain` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@
 members = [
     "dexios",
     "dexios-core",
+    "dexios-domain",
 ]

--- a/dexios-domain/Cargo.toml
+++ b/dexios-domain/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "dexios-domain"
+description = "A library that contains the inner-workings of Dexios."
+version = "0.0.0"
+edition = "2021"
+license = "BSD-2-Clause"
+keywords = ["encryption", "secure"]
+categories = ["cryptography", "encoding", "data-structures"]
+repository = "https://github.com/brxken128/dexios/tree/master/dexios-domain"
+homepage = "https://github.com/brxken128/dexios"
+documentation = "https://docs.rs/dexios-domain/latest/dexios_domain/"
+readme = "README.md"
+authors = ["brxken128 <brxken128@tutanota.com"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/dexios-domain/README.md
+++ b/dexios-domain/README.md
@@ -1,0 +1,3 @@
+## Dexios-Domain
+
+This crate is currently a work in progress, and will be used in the near future.


### PR DESCRIPTION
The move to `domain` should be relatively soon, so it makes sense to add a workspace member for it.

Either way, I have [published it to crates.io](https://crates.io/crates/dexios-domain).

The actual migration will be a large task, and I don't mind doing it myself provided the majority of the core logic has been isolated (it has!)