### PR TITLE
[DEPS] Remove `hex` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,6 @@ dependencies = [
  "clap",
  "dexios-core",
  "dexios-domain",
- "hex",
  "paris",
  "rand",
  "rpassword",
@@ -412,12 +411,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "indexmap"

--- a/dexios/Cargo.toml
+++ b/dexios/Cargo.toml
@@ -27,8 +27,6 @@ rand = "0.8.5"
 domain = { package = "dexios-domain", version = "0", path = "../dexios-domain" }
 dexios-core = { path = "../dexios-core", version = "1.1.1", default-features = false, features = ["visual"] }
 
-hex = "0.4.3"
-
 clap = { version = "3.2.14", features = ["cargo"] }
 anyhow = "1.0.57"
 paris = { version = "1.5.13", features = ["macros"] }

--- a/dexios/src/subcommands/header.rs
+++ b/dexios/src/subcommands/header.rs
@@ -11,7 +11,7 @@ use dexios_core::header::HashingAlgorithm;
 use dexios_core::header::{Header, HeaderVersion};
 use paris::Logger;
 
-pub fn hex_encode(bytes: &[u8]) -> String {
+fn hex_encode(bytes: &[u8]) -> String {
     bytes
         .iter()
         .map(|b| format!("{:02x}", b))


### PR DESCRIPTION
This is part of our cleanup, specified in #171.

This just uses a simple conversion function from `&[u8]` to hex, via `format!()`.

It's private as there's nowhere else in the codebase that currently uses it, aside from `header/details`. There's probably a better place for it though.