### PR TITLE
ci: disable windows unit tests temporarily

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
+          # - windows-latest
           - macos-latest
         rust:
           - stable


### PR DESCRIPTION
This is so we don't get failing tests on every PR actions run.

I assume the error is within our unit tests, and probably something to do with Windows paths (and how abysmal they are in relation to every other OS). It will get fixed at some point, but for the time being I suggest we just disable it.

This will also prevent email spam for every commit on every PR (my inbox will greatly appreciate it!)