### PR TITLE
[DEPS] Remove `paris` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,6 @@ dependencies = [
  "clap",
  "dexios-core",
  "dexios-domain",
- "paris",
  "rand",
  "rpassword",
  "zip",
@@ -478,12 +477,6 @@ name = "os_str_bytes"
 version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
-
-[[package]]
-name = "paris"
-version = "1.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eaf2319cd71dd9ff38c72bebde61b9ea657134abcf26ae4205f54f772a32810"
 
 [[package]]
 name = "password-hash"

--- a/dexios/Cargo.toml
+++ b/dexios/Cargo.toml
@@ -29,7 +29,6 @@ dexios-core = { path = "../dexios-core", version = "1.1.1", default-features = f
 
 clap = { version = "3.2.15", features = ["cargo"] }
 anyhow = "1.0.57"
-paris = { version = "1.5.13", features = ["macros"] }
 
 zip = { version = "0.6.2", default-features = false, features = ["zstd"] }
 rpassword = "7.0"

--- a/dexios/src/cli.rs
+++ b/dexios/src/cli.rs
@@ -434,7 +434,7 @@ pub fn get_matches() -> clap::ArgMatches {
                                 .takes_value(true)
                                 .help("Use an old keyfile to decrypt the master key"),
                         ),
-                )       
+                )
          )
         .subcommand(
             Command::new("header")

--- a/dexios/src/global.rs
+++ b/dexios/src/global.rs
@@ -1,3 +1,31 @@
 pub mod parameters;
 pub mod states;
 pub mod structs;
+
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)*) => {
+        println!("[i] {}", format!($($arg)*))
+    }
+}
+
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)*) => {
+        println!("[!] {}", format!($($arg)*))
+    }
+}
+
+#[macro_export]
+macro_rules! success {
+    ($($arg:tt)*) => {
+        println!("[+] {}", format!($($arg)*))
+    }
+}
+
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)*) => {
+        println!("[-] {}", format!($($arg)*))
+    }
+}

--- a/dexios/src/global.rs
+++ b/dexios/src/global.rs
@@ -29,3 +29,11 @@ macro_rules! warn {
         println!("[-] {}", format!($($arg)*))
     }
 }
+
+#[macro_export]
+macro_rules! question {
+    ($($arg:tt)*) => {
+        print!("[?] {}", format!($($arg)*));
+        
+    }
+}

--- a/dexios/src/global.rs
+++ b/dexios/src/global.rs
@@ -34,6 +34,6 @@ macro_rules! warn {
 macro_rules! question {
     ($($arg:tt)*) => {
         print!("[?] {}", format!($($arg)*));
-        
+
     }
 }

--- a/dexios/src/global/parameters.rs
+++ b/dexios/src/global/parameters.rs
@@ -4,10 +4,10 @@
 use crate::global::states::{EraseMode, EraseSourceDir, HashMode, HeaderLocation, SkipMode};
 use crate::global::structs::CryptoParams;
 use crate::global::structs::PackParams;
+use crate::warn;
 use anyhow::{Context, Result};
 use clap::ArgMatches;
 use dexios_core::primitives::Algorithm;
-use paris::warn;
 
 use dexios_core::primitives::ALGORITHMS;
 

--- a/dexios/src/global/states.rs
+++ b/dexios/src/global/states.rs
@@ -9,7 +9,8 @@ use dexios_core::protected::Protected;
 
 use crate::{
     file::get_bytes,
-    subcommands::key::{generate_passphrase, get_password}, warn,
+    subcommands::key::{generate_passphrase, get_password},
+    warn,
 };
 
 #[derive(PartialEq, Eq, Clone, Copy)]

--- a/dexios/src/global/states.rs
+++ b/dexios/src/global/states.rs
@@ -6,11 +6,10 @@
 use anyhow::{Context, Result};
 use clap::ArgMatches;
 use dexios_core::protected::Protected;
-use paris::warn;
 
 use crate::{
     file::get_bytes,
-    subcommands::key::{generate_passphrase, get_password},
+    subcommands::key::{generate_passphrase, get_password}, warn,
 };
 
 #[derive(PartialEq, Eq, Clone, Copy)]

--- a/dexios/src/subcommands/decrypt.rs
+++ b/dexios/src/subcommands/decrypt.rs
@@ -5,9 +5,9 @@ use std::time::Instant;
 use super::prompt::overwrite_check;
 use crate::global::states::{EraseMode, HashMode, HeaderLocation, PasswordState};
 use crate::global::structs::CryptoParams;
+use crate::{info, success};
 
 use anyhow::Result;
-use paris::Logger;
 
 use domain::storage::Storage;
 
@@ -19,8 +19,6 @@ use domain::storage::Storage;
 pub fn stream_mode(input: &str, output: &str, params: &CryptoParams) -> Result<()> {
     // TODO: It is necessary to raise it to a higher level
     let stor = Arc::new(domain::storage::FileStorage);
-
-    let mut logger = Arc::new(Logger::new());
 
     // 1. validate and prepare options
     if input == output {
@@ -44,22 +42,17 @@ pub fn stream_mode(input: &str, output: &str, params: &CryptoParams) -> Result<(
         .create_file(output)
         .or_else(|_| stor.write_file(output))?;
 
-    if let Some(l) = Arc::get_mut(&mut logger) {
-        l.info(format!("Decrypting {} (this may take a while)", input));
-    }
+    info!("Decrypting {} (this may take a while)", input);
 
     // 2. decrypt file
     let start_time = Instant::now();
-    let mut inner_logger = logger.clone();
     domain::decrypt::execute(domain::decrypt::Request {
         header_reader: header_file.as_ref().and_then(|h| h.try_reader().ok()),
         reader: input_file.try_reader()?,
         writer: output_file.try_writer()?,
         raw_key,
         on_decrypted_header: Some(Box::new(move |header_type| {
-            if let Some(l) = Arc::get_mut(&mut inner_logger) {
-                l.info(format!("Using {} for decryption", header_type.algorithm));
-            }
+                info!("Using {} for decryption", header_type.algorithm);
         })),
     })?;
 
@@ -67,13 +60,11 @@ pub fn stream_mode(input: &str, output: &str, params: &CryptoParams) -> Result<(
     stor.flush_file(&output_file)?;
 
     let decrypt_duration = start_time.elapsed();
-    if let Some(l) = Arc::get_mut(&mut logger) {
-        l.success(format!(
+        success!(
             "Decryption successful! File saved as {} [took {:.2}s]",
             output,
             decrypt_duration.as_secs_f32(),
-        ));
-    }
+        );
 
     if params.hash_mode == HashMode::CalculateHash {
         super::hashing::hash_stream(&[input.to_string()])?;

--- a/dexios/src/subcommands/decrypt.rs
+++ b/dexios/src/subcommands/decrypt.rs
@@ -52,7 +52,7 @@ pub fn stream_mode(input: &str, output: &str, params: &CryptoParams) -> Result<(
         writer: output_file.try_writer()?,
         raw_key,
         on_decrypted_header: Some(Box::new(move |header_type| {
-                info!("Using {} for decryption", header_type.algorithm);
+            info!("Using {} for decryption", header_type.algorithm);
         })),
     })?;
 
@@ -60,11 +60,11 @@ pub fn stream_mode(input: &str, output: &str, params: &CryptoParams) -> Result<(
     stor.flush_file(&output_file)?;
 
     let decrypt_duration = start_time.elapsed();
-        success!(
-            "Decryption successful! File saved as {} [took {:.2}s]",
-            output,
-            decrypt_duration.as_secs_f32(),
-        );
+    success!(
+        "Decryption successful! File saved as {} [took {:.2}s]",
+        output,
+        decrypt_duration.as_secs_f32(),
+    );
 
     if params.hash_mode == HashMode::CalculateHash {
         super::hashing::hash_stream(&[input.to_string()])?;

--- a/dexios/src/subcommands/encrypt.rs
+++ b/dexios/src/subcommands/encrypt.rs
@@ -1,10 +1,10 @@
 use super::prompt::overwrite_check;
 use crate::global::states::{EraseMode, HashMode, HeaderLocation, PasswordState};
 use crate::global::structs::CryptoParams;
+use crate::{info, success};
 use anyhow::Result;
 use dexios_core::header::{HashingAlgorithm, HeaderType, HEADER_VERSION};
 use dexios_core::primitives::{Algorithm, Mode};
-use paris::Logger;
 use std::process::exit;
 use std::sync::Arc;
 use std::time::Instant;
@@ -22,8 +22,6 @@ pub fn stream_mode(
 ) -> Result<()> {
     // TODO: It is necessary to raise it to a higher level
     let stor = Arc::new(domain::storage::FileStorage);
-
-    let mut logger = Logger::new();
 
     // 1. validate and prepare options
     if input == output {
@@ -53,8 +51,8 @@ pub fn stream_mode(
         }
     };
 
-    logger.info(format!("Using {} for encryption", algorithm));
-    logger.info(format!("Encrypting {} (this may take a while)", input));
+    info!("Using {} for encryption", algorithm);
+    info!("Encrypting {} (this may take a while)", input);
 
     let start_time = Instant::now();
 
@@ -80,11 +78,11 @@ pub fn stream_mode(
     stor.flush_file(&output_file)?;
 
     let encrypt_duration = start_time.elapsed();
-    logger.success(format!(
+    success!(
         "Encryption successful! File saved as {} [took {:.2}s]",
         output,
         encrypt_duration.as_secs_f32(),
-    ));
+    );
 
     if params.hash_mode == HashMode::CalculateHash {
         super::hashing::hash_stream(&[output.to_string()])?;

--- a/dexios/src/subcommands/erase.rs
+++ b/dexios/src/subcommands/erase.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use domain::storage::Storage;
-use paris::Logger;
 use std::sync::Arc;
 use std::time::Instant;
+
+use crate::{info, success};
 
 use super::prompt::get_answer;
 
@@ -24,12 +25,11 @@ pub fn secure_erase(input: &str, passes: i32) -> Result<()> {
         std::process::exit(0);
     }
 
-    let mut logger = Logger::new();
     let start_time = Instant::now();
-    logger.loading(format!(
+    info!(
         "Erasing {} with {} passes (this may take a while)",
         input, passes
-    ));
+    );
 
     if file.is_dir() {
         domain::erase_dir::execute(
@@ -39,8 +39,6 @@ pub fn secure_erase(input: &str, passes: i32) -> Result<()> {
                 passes,
             },
         )?;
-
-        logger.success(format!("Deleted directory: {}", input));
     } else {
         domain::erase::execute(
             stor,
@@ -52,11 +50,11 @@ pub fn secure_erase(input: &str, passes: i32) -> Result<()> {
     }
 
     let duration = start_time.elapsed();
-    logger.done().success(format!(
+    success!(
         "Erased {} successfully [took {:.2}s]",
         input,
         duration.as_secs_f32()
-    ));
+    );
 
     Ok(())
 }

--- a/dexios/src/subcommands/hashing.rs
+++ b/dexios/src/subcommands/hashing.rs
@@ -1,13 +1,13 @@
 use anyhow::Context;
 use anyhow::Result;
-use paris::Logger;
 use std::cell::RefCell;
+
+use crate::success;
 
 // this hashes the input file
 // it reads it in blocks, updates the hasher, and finalises/displays the hash
 // it's used by hash-standalone mode
 pub fn hash_stream(files: &[String]) -> Result<()> {
-    let mut logger = Logger::new();
     for input in files {
         let mut input_file = std::fs::File::open(input)
             .with_context(|| format!("Unable to open file: {}", input))?;
@@ -19,7 +19,7 @@ pub fn hash_stream(files: &[String]) -> Result<()> {
             },
         )?;
 
-        logger.success(format!("{}: {}", input, hash));
+        success!("{}: {}", input, hash);
     }
 
     Ok(())

--- a/dexios/src/subcommands/header.rs
+++ b/dexios/src/subcommands/header.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use super::prompt::{get_answer, overwrite_check};
-use crate::{global::states::SkipMode, error, success, warn};
+use crate::{error, global::states::SkipMode, success, warn};
 use anyhow::{Context, Result};
 use dexios_core::header::HashingAlgorithm;
 use dexios_core::header::{Header, HeaderVersion};
@@ -149,10 +149,7 @@ pub fn restore(input: &str, output: &str, skip: SkipMode) -> Result<()> {
 
     header.write(&mut output_file)?;
 
-    success!(
-        "Header restored to {} from {} successfully.",
-        output, input
-    );
+    success!("Header restored to {} from {} successfully.", output, input);
     Ok(())
 }
 

--- a/dexios/src/subcommands/header_key.rs
+++ b/dexios/src/subcommands/header_key.rs
@@ -3,6 +3,8 @@ use std::{fs::OpenOptions, io::Seek};
 
 use crate::global::states::Key;
 use crate::global::states::PasswordState;
+use crate::info;
+use crate::success;
 use anyhow::{Context, Result};
 use dexios_core::header::HashingAlgorithm;
 use dexios_core::header::{Header, HeaderVersion};
@@ -15,8 +17,6 @@ use dexios_core::Zeroize;
 use dexios_core::{cipher::Ciphers, header::Keyslot};
 use dexios_core::{key::balloon_hash, primitives::gen_nonce};
 use domain::utils::gen_salt;
-use paris::info;
-use paris::success;
 use std::time::Instant;
 
 // this functions take both an old and a new key state

--- a/dexios/src/subcommands/key.rs
+++ b/dexios/src/subcommands/key.rs
@@ -1,10 +1,9 @@
 use anyhow::{Context, Result};
 use dexios_core::protected::Protected;
 use dexios_core::Zeroize;
-use paris::warn;
 use rand::{prelude::StdRng, Rng, SeedableRng};
 
-use crate::global::states::PasswordState;
+use crate::{global::states::PasswordState, warn};
 
 // this interactively gets the user's password from the terminal
 // it takes the password twice, compares, and returns the bytes

--- a/dexios/src/subcommands/pack.rs
+++ b/dexios/src/subcommands/pack.rs
@@ -7,7 +7,6 @@ use dexios_core::header::{HashingAlgorithm, HeaderType, HEADER_VERSION};
 use dexios_core::primitives::{Algorithm, Mode};
 
 use crate::global::states::{HeaderLocation, PasswordState};
-use crate::{info, success};
 use crate::{
     global::states::EraseSourceDir,
     global::{
@@ -15,6 +14,7 @@ use crate::{
         structs::{CryptoParams, PackParams},
     },
 };
+use crate::{info, success};
 use domain::storage::Storage;
 
 use super::prompt::overwrite_check;
@@ -35,7 +35,6 @@ pub struct Request<'a> {
 pub fn execute(req: Request) -> Result<()> {
     // TODO: It is necessary to raise it to a higher level
     let stor = Arc::new(domain::storage::FileStorage);
-
 
     // 1. validate and prepare options
     if req.input_file.iter().any(|f| f == req.output_file) {
@@ -90,10 +89,7 @@ pub fn execute(req: Request) -> Result<()> {
     };
 
     info!("Using {} for encryption", req.algorithm);
-    info!(
-        "Encrypting {:?} (this may take a while)",
-        req.input_file
-    );
+    info!("Encrypting {:?} (this may take a while)", req.input_file);
 
     let start_time = Instant::now();
     // 2. compress and encrypt files

--- a/dexios/src/subcommands/pack.rs
+++ b/dexios/src/subcommands/pack.rs
@@ -5,9 +5,9 @@ use std::time::Instant;
 use anyhow::Result;
 use dexios_core::header::{HashingAlgorithm, HeaderType, HEADER_VERSION};
 use dexios_core::primitives::{Algorithm, Mode};
-use paris::Logger;
 
 use crate::global::states::{HeaderLocation, PasswordState};
+use crate::{info, success};
 use crate::{
     global::states::EraseSourceDir,
     global::{
@@ -36,7 +36,6 @@ pub fn execute(req: Request) -> Result<()> {
     // TODO: It is necessary to raise it to a higher level
     let stor = Arc::new(domain::storage::FileStorage);
 
-    let mut logger = Logger::new();
 
     // 1. validate and prepare options
     if req.input_file.iter().any(|f| f == req.output_file) {
@@ -90,11 +89,11 @@ pub fn execute(req: Request) -> Result<()> {
         Compression::Zstd => zip::CompressionMethod::Zstd,
     };
 
-    logger.info(format!("Using {} for encryption", req.algorithm));
-    logger.info(format!(
+    info!("Using {} for encryption", req.algorithm);
+    info!(
         "Encrypting {:?} (this may take a while)",
         req.input_file
-    ));
+    );
 
     let start_time = Instant::now();
     // 2. compress and encrypt files
@@ -122,11 +121,11 @@ pub fn execute(req: Request) -> Result<()> {
     stor.flush_file(&output_file)?;
 
     let encrypt_duration = start_time.elapsed();
-    logger.success(format!(
+    success!(
         "Encryption successful! File saved as {} [took {:.2}s]",
         req.output_file,
         encrypt_duration.as_secs_f32(),
-    ));
+    );
 
     if req.pack_params.erase_source == EraseSourceDir::Erase {
         req.input_file
@@ -134,7 +133,7 @@ pub fn execute(req: Request) -> Result<()> {
             .try_for_each(|file_name| super::erase::secure_erase(file_name, 2))?;
     }
 
-    logger.success(format!("Your output file is: {}", req.output_file));
+    success!("Your output file is: {}", req.output_file);
 
     Ok(())
 }

--- a/dexios/src/subcommands/prompt.rs
+++ b/dexios/src/subcommands/prompt.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use std::io::{self, stdin, Write};
 
-use crate::{global::states::SkipMode, warn, question};
+use crate::{global::states::SkipMode, question, warn};
 
 // this handles user-interactivity, specifically getting a "yes" or "no" answer from the user
 // it requires the question itself, if the default is true/false

--- a/dexios/src/subcommands/prompt.rs
+++ b/dexios/src/subcommands/prompt.rs
@@ -1,8 +1,7 @@
 use anyhow::{Context, Result};
-use paris::{warn, Logger};
 use std::io::{self, stdin, Write};
 
-use crate::global::states::SkipMode;
+use crate::{global::states::SkipMode, warn, question};
 
 // this handles user-interactivity, specifically getting a "yes" or "no" answer from the user
 // it requires the question itself, if the default is true/false
@@ -15,9 +14,7 @@ pub fn get_answer(prompt: &str, default: bool, skip: bool) -> Result<bool> {
     let switch = if default { "(Y/n)" } else { "(y/N)" };
 
     let answer_bool = loop {
-        let mut logger = Logger::new();
-
-        logger.same().warn(format!("{prompt} {switch}: "));
+        question!("{prompt} {switch}: ");
         io::stdout().flush().context("Unable to flush stdout")?;
 
         let mut answer = String::new();

--- a/dexios/src/subcommands/unpack.rs
+++ b/dexios/src/subcommands/unpack.rs
@@ -1,10 +1,13 @@
 use anyhow::{Context, Result};
 use rand::distributions::{Alphanumeric, DistString};
 
-use crate::{global::{
-    states::{PrintMode, SkipMode},
-    structs::CryptoParams,
-}, info, warn, success};
+use crate::{
+    global::{
+        states::{PrintMode, SkipMode},
+        structs::CryptoParams,
+    },
+    info, success, warn,
+};
 use std::fs::File;
 use std::path::PathBuf;
 use std::{str::FromStr, time::Instant};
@@ -40,10 +43,7 @@ pub fn unpack(
 
     let file_count = archive.len();
 
-    info!(
-        "Decompressing {} items into {}",
-        file_count, output
-    );
+    info!("Decompressing {} items into {}", file_count, output);
 
     for i in 0..file_count {
         // recreate the directory structure first


### PR DESCRIPTION
This PR removes our reliance on `paris`.

It does not have fancy colours and icons, but we can always add those later on (at least the colours).

It just uses a set of 5 macros which format the statement, print and prefix `[!]` or similar to the start.

There are 5 potential prefixes:
* `[?]` for questions
* `[i]` for information
* `[!]` for errors
* `[-]` for warnings
* `[+]` for successes