### PR TITLE
release: update crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "dexios"
-version = "8.7.0"
+version = "8.8.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "dexios-core"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "dexios-domain"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "blake3",
  "dexios-core",

--- a/dexios-core/Cargo.toml
+++ b/dexios-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dexios-core"
 description = "A library for encrypting/decrypting, password hashing, and for managing encrypted file headers that adhere to the Dexios format."
-version = "1.1.1"
+version = "1.2.0"
 readme = "README.md"
 authors = ["brxken128 <brxken128@tutanota.com>"]
 homepage = "https://github.com/brxken128/dexios"

--- a/dexios-domain/Cargo.toml
+++ b/dexios-domain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dexios-domain"
 description = "A library that contains the inner-workings and core logic for Dexios."
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 license = "BSD-2-Clause"
 keywords = ["encryption", "secure"]
@@ -19,7 +19,7 @@ authors = ["brxken128 <brxken128@tutanota.com"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-dcore = { package = "dexios-core", path = "../dexios-core", version = "1.1.1" }
+dcore = { package = "dexios-core", path = "../dexios-core", version = "1.2.0" }
 
 rand = "0.8.5"
 blake3 = "1.3.1"

--- a/dexios/Cargo.toml
+++ b/dexios/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dexios"
-version = "8.7.0"
+version = "8.8.0"
 authors = ["brxken128 <brxken128@tutanota.com>"]
 readme = "README.md"
 edition = "2021"
@@ -21,8 +21,8 @@ maintenance = { status = "actively-developed" }
 blake3 = "1.3.1"
 rand = "0.8.5"
 
-domain = { package = "dexios-domain", version = "0", path = "../dexios-domain" }
-dcore = { package = "dexios-core", path = "../dexios-core", version = "1.1.1" }
+domain = { package = "dexios-domain", version = "1.0.0", path = "../dexios-domain" }
+dcore = { package = "dexios-core", path = "../dexios-core", version = "1.2.0" }
 
 clap = { version = "3.2.17", features = ["cargo"] }
 anyhow = "1.0.62"


### PR DESCRIPTION
This will update `core` to `v1.2.0`, `domain` to `v1.0.0` and `dexios` itself to `v8.8.0`.

Once this merges I'll publish the new versions to crates.io, and release the binaries here.