### PR TITLE
pack+mem: fix stack overflow issues

### DIFF
--- a/dexios-domain/src/hash.rs
+++ b/dexios-domain/src/hash.rs
@@ -36,7 +36,7 @@ pub fn execute<R: Read + Seek>(mut hasher: impl Hasher, req: Request<R>) -> Resu
         .rewind()
         .map_err(|_| Error::ResetCursorPosition)?;
 
-    let mut buffer = vec![0u8; BLOCK_SIZE];
+    let mut buffer = vec![0u8; BLOCK_SIZE].into_boxed_slice();;
 
     loop {
         let read_count = req

--- a/dexios-domain/src/pack.rs
+++ b/dexios-domain/src/pack.rs
@@ -87,7 +87,7 @@ where
                     .map_err(|_| Error::AddFileToArchive)?;
 
                 let mut reader = f.try_reader().map_err(|_| Error::ReadData)?.borrow_mut();
-                let mut buffer = [0u8; BLOCK_SIZE];
+                let mut buffer = vec![0u8; BLOCK_SIZE].into_boxed_slice();
                 loop {
                     let read_count = reader.read(&mut buffer).map_err(|_| Error::ReadData)?;
                     zip_writer


### PR DESCRIPTION
It looks as though while moving to `domain`, something was incorrectly copied over and we were allocating a full 1MiB array on the stack. Windows' stack size is considerably smaller than other OSes, such as Linux, so this issue slipped through the cracks.