### PR TITLE
feature: add key verification

### DIFF
--- a/dexios-core/src/header.rs
+++ b/dexios-core/src/header.rs
@@ -105,7 +105,6 @@ pub struct Header {
 pub const ARGON2ID_LATEST: i32 = 3;
 pub const BLAKE3BALLOON_LATEST: i32 = 5;
 
-
 /// This is in place to make `Keyslot` handling a **lot** easier
 /// You may use the constants `ARGON2ID_LATEST` and `BLAKE3BALLOON_LATEST` for defining versions
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -647,7 +646,7 @@ impl Header {
     /// It only has support for V3 headers and above
     ///
     /// It will return the bytes used for AAD
-    /// 
+    ///
     /// You may view more about what is used as AAD [here](https://brxken128.github.io/dexios/dexios-core/Headers.html#authenticating-the-header-with-aad-v840).
     pub fn create_aad(&self) -> Result<Vec<u8>> {
         let tag = self.get_tag();

--- a/dexios-core/src/key.rs
+++ b/dexios-core/src/key.rs
@@ -133,13 +133,12 @@ pub fn balloon_hash(
     Ok(Protected::new(key))
 }
 
-
 /// This is a helper function for retrieving the key used for encrypting the data
-/// 
+///
 /// In header versions below V4, this is just the hashed password
-/// 
+///
 /// In header versions >= V4, this is a cryptographically-secure random value
-/// 
+///
 /// In header versions >= V4, this function will iterate through all available keyslots, looking for a match. If it finds a match, it will return the decrypted master key.
 #[allow(clippy::module_name_repetitions)]
 pub fn decrypt_master_key(
@@ -196,11 +195,11 @@ pub fn vec_to_arr<const N: usize>(mut master_key_vec: Vec<u8>) -> [u8; N] {
 }
 
 /// This function is used for autogenerating a passphrase, from a wordlist
-/// 
+///
 /// It consists of 3 words, from the EFF wordlist, and 6 random digits appended to the end
-/// 
+///
 /// Each word, and the block of digits, are separated with `-`
-/// 
+///
 /// This provides adequate protection, while also remaining somewhat memorable.
 #[must_use]
 pub fn generate_passphrase() -> Protected<String> {

--- a/dexios-core/src/lib.rs
+++ b/dexios-core/src/lib.rs
@@ -32,6 +32,7 @@
 //! ## Thank you!
 //!
 //! Dexios-Core exclusively uses AEADs provided by the [RustCrypto Team](https://github.com/RustCrypto), so I'd like to give them a huge thank you for their hard work (this wouldn't have been possible without them!)
+#![forbid(unsafe_code)]
 #![deny(clippy::all)]
 
 pub const CORE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/dexios-core/src/visual.rs
+++ b/dexios-core/src/visual.rs
@@ -1,7 +1,7 @@
 //! This module offers visual functionality within `dexios-core`.
-//! 
+//!
 //! It isn't rather populated, nor does `dexios` itself use it, but the option is always there.
-//! 
+//!
 //! This can be enabled with the `visual` feature, and you will notice a blue spinner on encryption and decryption - useful for knowing that something is still happening.
 
 #[cfg(feature = "visual")]
@@ -10,7 +10,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 #[cfg(feature = "visual")]
 #[must_use]
 /// This creates a visual spinner, which can be enabled with the `visual` feature.
-/// 
+///
 /// The spinner is used for both encrypting and decrypting, provided the feature is enabled.
 pub fn create_spinner() -> ProgressBar {
     let pb = ProgressBar::new_spinner();

--- a/dexios-domain/src/erase.rs
+++ b/dexios-domain/src/erase.rs
@@ -1,5 +1,5 @@
 //! This provides functionality for "shredding" a file.
-//! 
+//!
 //! This will not be effective on flash storage, and if you are planning to release a program that uses this function, I'd recommend putting the default number of passes to 1.
 
 use std::io::{Read, Seek, Write};

--- a/dexios-domain/src/erase_dir.rs
+++ b/dexios-domain/src/erase_dir.rs
@@ -1,5 +1,5 @@
 //! This provides functionality for "shredding" a directory. It first traverses the directory, and then calls `shred` on all files.
-//! 
+//!
 //! This will not be effective on flash storage, and if you are planning to release a program that uses this function, I'd recommend putting the default number of passes to 1.
 
 use std::io::{Read, Seek, Write};

--- a/dexios-domain/src/key.rs
+++ b/dexios-domain/src/key.rs
@@ -41,9 +41,7 @@ impl std::fmt::Display for Error {
             Error::Unsupported => {
                 f.write_str("The provided request is unsupported with this header version")
             }
-            Error::IncorrectKey => {
-                f.write_str("The provided key is incorrect")
-            }
+            Error::IncorrectKey => f.write_str("The provided key is incorrect"),
         }
     }
 }

--- a/dexios-domain/src/key.rs
+++ b/dexios-domain/src/key.rs
@@ -9,6 +9,7 @@ use core::{cipher::Ciphers, header::Keyslot};
 pub mod add;
 pub mod change;
 pub mod delete;
+pub mod verify;
 
 #[derive(Debug)]
 pub enum Error {
@@ -47,7 +48,7 @@ impl std::fmt::Display for Error {
     }
 }
 
-pub fn decrypt_master_key_with_index(
+pub fn decrypt_v5_master_key_with_index(
     keyslots: &[Keyslot],
     raw_key_old: Protected<Vec<u8>>,
     algorithm: &Algorithm,

--- a/dexios-domain/src/key.rs
+++ b/dexios-domain/src/key.rs
@@ -42,7 +42,7 @@ impl std::fmt::Display for Error {
                 f.write_str("The provided request is unsupported with this header version")
             }
             Error::IncorrectKey => {
-                f.write_str("Unable to decrypt the master key (maybe you supplied the wrong key?)")
+                f.write_str("The provided key is incorrect")
             }
         }
     }

--- a/dexios-domain/src/key/add.rs
+++ b/dexios-domain/src/key/add.rs
@@ -48,7 +48,7 @@ where
     let mut keyslots = header.keyslots.clone().unwrap();
 
     // all of these functions need either the master key, or the index
-    let (master_key, _) = super::decrypt_master_key_with_index(
+    let (master_key, _) = super::decrypt_v5_master_key_with_index(
         &keyslots,
         req.raw_key_old,
         &header.header_type.algorithm,

--- a/dexios-domain/src/key/change.rs
+++ b/dexios-domain/src/key/change.rs
@@ -48,7 +48,7 @@ where
     let mut keyslots = header.keyslots.clone().unwrap();
 
     // all of these functions need either the master key, or the index
-    let (master_key, index) = super::decrypt_master_key_with_index(
+    let (master_key, index) = super::decrypt_v5_master_key_with_index(
         &keyslots,
         req.raw_key_old,
         &header.header_type.algorithm,

--- a/dexios-domain/src/key/delete.rs
+++ b/dexios-domain/src/key/delete.rs
@@ -40,7 +40,7 @@ where
     let mut keyslots = header.keyslots.clone().unwrap();
 
     // all of these functions need either the master key, or the index
-    let (_, index) = super::decrypt_master_key_with_index(
+    let (_, index) = super::decrypt_v5_master_key_with_index(
         &keyslots,
         req.raw_key_old,
         &header.header_type.algorithm,

--- a/dexios-domain/src/key/verify.rs
+++ b/dexios-domain/src/key/verify.rs
@@ -1,0 +1,43 @@
+//! This provides functionality for verifying that a decryption key is correct (header version >= V5)
+
+use std::io::Seek;
+
+use super::Error;
+use core::header::HeaderVersion;
+use core::protected::Protected;
+use std::cell::RefCell;
+use std::io::Read;
+
+pub struct Request<'a, R>
+where
+    R: Read + Seek,
+{
+    pub handle: &'a RefCell<R>, // header read+write+seek
+    pub raw_key: Protected<Vec<u8>>,
+}
+
+pub fn execute<R>(req: Request<'_, R>) -> Result<(), Error>
+where
+    R: Read + Seek,
+{
+    let (header, _) = core::header::Header::deserialize(&mut *req.handle.borrow_mut())
+        .map_err(|_| Error::HeaderDeserialize)?;
+
+    if header.header_type.version < HeaderVersion::V5 {
+        return Err(Error::Unsupported);
+    }
+
+    let keyslots = header.keyslots.clone().unwrap();
+
+    // all of these functions need either the master key, or the index
+    let (master_key, _) = super::decrypt_v5_master_key_with_index(
+        &keyslots,
+        req.raw_key,
+        &header.header_type.algorithm,
+    )?;
+
+    // ensure the master key is gone from memory in the event that the key is correct
+    drop(master_key);
+
+    Ok(())
+}

--- a/dexios-domain/src/lib.rs
+++ b/dexios-domain/src/lib.rs
@@ -33,10 +33,11 @@
 //!
 
 // Rustc lints
+#![forbid(unsafe_code)]
+
 #![deny(
     rust_2018_idioms,
     non_ascii_idents,
-    unsafe_code,
     unstable_features,
     unused_imports,
     unused_qualifications

--- a/dexios-domain/src/lib.rs
+++ b/dexios-domain/src/lib.rs
@@ -16,7 +16,7 @@
 //! encryption utility.
 //!
 //! This crate was made to separate the logic away from the end-user application.
-//! 
+//!
 //! It also allows for more things to be built on top of the core functionality, such as a GUI application.
 //!
 //! ## Donating
@@ -34,7 +34,6 @@
 
 // Rustc lints
 #![forbid(unsafe_code)]
-
 #![deny(
     rust_2018_idioms,
     non_ascii_idents,

--- a/dexios-domain/src/overwrite.rs
+++ b/dexios-domain/src/overwrite.rs
@@ -1,5 +1,5 @@
 //! This contains the actual logic for "shredding" a file.
-//! 
+//!
 //! This will not be effective on flash storage, and if you are planning to release a program that uses this function, I'd recommend putting the default number of passes to 1.
 
 use rand::RngCore;

--- a/dexios/src/cli.rs
+++ b/dexios/src/cli.rs
@@ -359,7 +359,7 @@ pub fn get_matches() -> clap::ArgMatches {
                                 .value_name("input")
                                 .takes_value(true)
                                 .required(true)
-                                .help("The encrypted file"),
+                                .help("The encrypted file/header file"),
                         )
                         .arg(
                             Arg::new("autogenerate")
@@ -400,7 +400,7 @@ pub fn get_matches() -> clap::ArgMatches {
                                 .value_name("input")
                                 .takes_value(true)
                                 .required(true)
-                                .help("The encrypted file"),
+                                .help("The encrypted file/header file"),
                         )
                         .arg(
                             Arg::new("argon")
@@ -441,7 +441,7 @@ pub fn get_matches() -> clap::ArgMatches {
                                 .value_name("input")
                                 .takes_value(true)
                                 .required(true)
-                                .help("The encrypted file"),
+                                .help("The encrypted file/header file"),
                         )
                         .arg(
                             Arg::new("keyfile")
@@ -461,7 +461,7 @@ pub fn get_matches() -> clap::ArgMatches {
                                 .value_name("input")
                                 .takes_value(true)
                                 .required(true)
-                                .help("The encrypted file"),
+                                .help("The encrypted file/header file"),
                         )
                         .arg(
                             Arg::new("keyfile")

--- a/dexios/src/cli.rs
+++ b/dexios/src/cli.rs
@@ -446,10 +446,30 @@ pub fn get_matches() -> clap::ArgMatches {
                         .arg(
                             Arg::new("keyfile")
                                 .short('k')
-                                .long("keyfile-old")
+                                .long("keyfile")
                                 .value_name("file")
                                 .takes_value(true)
-                                .help("Use an old keyfile to decrypt the master key"),
+                                .help("Use a keyfile to identify the key you want to delete"),
+                        ),
+                )
+                .subcommand(
+                    Command::new("verify")
+                        .about("Verify that a key is correct")
+                        .arg_required_else_help(true)
+                        .arg(
+                            Arg::new("input")
+                                .value_name("input")
+                                .takes_value(true)
+                                .required(true)
+                                .help("The encrypted file"),
+                        )
+                        .arg(
+                            Arg::new("keyfile")
+                                .short('k')
+                                .long("keyfile")
+                                .value_name("file")
+                                .takes_value(true)
+                                .help("Verify a keyfile"),
                         ),
                 )
          )

--- a/dexios/src/main.rs
+++ b/dexios/src/main.rs
@@ -58,6 +58,9 @@ fn main() -> Result<()> {
             Some("del") => {
                 subcommands::key_del(sub_matches)?;
             }
+            Some("verify") => {
+                subcommands::key_verify(sub_matches)?;
+            }
             _ => (),
         },
         _ => (),

--- a/dexios/src/main.rs
+++ b/dexios/src/main.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![deny(clippy::all)]
 
 use anyhow::Result;

--- a/dexios/src/subcommands.rs
+++ b/dexios/src/subcommands.rs
@@ -155,4 +155,3 @@ pub fn key_verify(sub_matches: &ArgMatches) -> Result<()> {
 
     key::verify(&get_param("input", sub_matches_verify_key)?, &key)
 }
-

--- a/dexios/src/subcommands.rs
+++ b/dexios/src/subcommands.rs
@@ -148,3 +148,11 @@ pub fn key_del(sub_matches: &ArgMatches) -> Result<()> {
 
     key::delete(&get_param("input", sub_matches_del_key)?, &key)
 }
+
+pub fn key_verify(sub_matches: &ArgMatches) -> Result<()> {
+    let sub_matches_verify_key = sub_matches.subcommand_matches("verify").unwrap();
+    let key = Key::init(sub_matches_verify_key, &KeyParams::default(), "keyfile")?;
+
+    key::verify(&get_param("input", sub_matches_verify_key)?, &key)
+}
+

--- a/dexios/src/subcommands/key.rs
+++ b/dexios/src/subcommands/key.rs
@@ -122,7 +122,7 @@ pub fn delete(input: &str, key_old: &Key) -> Result<()> {
         .context("Unable to rewind the reader")?;
 
     if key_old == &Key::User {
-        info!("Please enter your old key below");
+        info!("Please enter your key below");
     }
 
     let raw_key_old = key_old.get_secret(&PasswordState::Direct)?;
@@ -157,7 +157,7 @@ pub fn verify(input: &str, key: &Key) -> Result<()> {
         .context("Unable to rewind the reader")?;
 
     if key == &Key::User {
-        info!("Please enter your old key below");
+        info!("Please enter your key below");
     }
 
     let raw_key = key.get_secret(&PasswordState::Direct)?;

--- a/dexios/src/subcommands/key.rs
+++ b/dexios/src/subcommands/key.rs
@@ -134,3 +134,38 @@ pub fn delete(input: &str, key_old: &Key) -> Result<()> {
 
     Ok(())
 }
+
+pub fn verify(input: &str, key: &Key) -> Result<()> {
+    let input_file = RefCell::new(
+        OpenOptions::new()
+            .read(true)
+            .open(input)
+            .with_context(|| format!("Unable to open input file: {}", input))?,
+    );
+
+    let (header, _) = Header::deserialize(&mut *input_file.borrow_mut())?;
+
+    if header.header_type.version < HeaderVersion::V5 {
+        return Err(anyhow::anyhow!(
+            "This function is not supported on header versions below V5"
+        ));
+    }
+
+    input_file
+        .borrow_mut()
+        .rewind()
+        .context("Unable to rewind the reader")?;
+
+    if key == &Key::User {
+        info!("Please enter your old key below");
+    }
+
+    let raw_key = key.get_secret(&PasswordState::Direct)?;
+
+    domain::key::verify::execute(domain::key::verify::Request {
+        handle: &input_file,
+        raw_key,
+    })?;
+
+    Ok(())
+}


### PR DESCRIPTION
This closes #228.

It allows a user to verify that a key is correct, without decrypting the entire file/piping the output to `/dev/null`. This also has the added benefit of working across multiple platforms.

It only supports V5 headers and above, as I think it's impractical for others (V3 and below would require the data to also be present).