### PR TITLE
core: tweak passphrase autogeneration

### DIFF
--- a/dexios-core/src/key.rs
+++ b/dexios-core/src/key.rs
@@ -211,14 +211,7 @@ pub fn generate_passphrase(total_words: &i32) -> Protected<String> {
     for i in 0..*total_words {
         let index = StdRng::from_entropy().gen_range(0..=words.len());
         let word = words[index];
-        let capitalized_word = word
-            .char_indices()
-            .map(|(i, ch)| match i {
-                0 => ch.to_ascii_uppercase(),
-                _ => ch,
-            })
-            .collect::<String>();
-        passphrase.push_str(&capitalized_word);
+        passphrase.push_str(word);
         if i < total_words - 1 {
             passphrase.push('-');
         }

--- a/dexios-core/src/key.rs
+++ b/dexios-core/src/key.rs
@@ -196,19 +196,19 @@ pub fn vec_to_arr<const N: usize>(mut master_key_vec: Vec<u8>) -> [u8; N] {
 
 /// This function is used for autogenerating a passphrase, from a wordlist
 ///
-/// It consists of 3 words, from the EFF wordlist, and 6 random digits appended to the end
+/// It consists of n words, from the EFF large wordlist. The default amount of words is 7.
 ///
-/// Each word, and the block of digits, are separated with `-`
+/// Each word is separated with `-`.
 ///
 /// This provides adequate protection, while also remaining somewhat memorable.
 #[must_use]
-pub fn generate_passphrase() -> Protected<String> {
+pub fn generate_passphrase(total_words: &i32) -> Protected<String> {
     let collection = include_str!("wordlist.lst");
     let words = collection.lines().collect::<Vec<_>>();
 
     let mut passphrase = String::new();
 
-    for _ in 0..3 {
+    for i in 0..*total_words {
         let index = StdRng::from_entropy().gen_range(0..=words.len());
         let word = words[index];
         let capitalized_word = word
@@ -219,12 +219,9 @@ pub fn generate_passphrase() -> Protected<String> {
             })
             .collect::<String>();
         passphrase.push_str(&capitalized_word);
-        passphrase.push('-');
-    }
-
-    for _ in 0..6 {
-        let number: i64 = StdRng::from_entropy().gen_range(0..=9);
-        passphrase.push_str(&number.to_string());
+        if i < total_words - 1 {
+            passphrase.push('-');
+        }
     }
 
     Protected::new(passphrase)

--- a/dexios/src/cli.rs
+++ b/dexios/src/cli.rs
@@ -58,8 +58,12 @@ pub fn get_matches() -> clap::ArgMatches {
         .arg(
             Arg::new("autogenerate")
                 .long("auto")
-                .takes_value(false)
-                .help("Autogenerate a passphrase")
+                .value_name("# of words")
+                .min_values(0)
+                .default_missing_value("7")
+                .takes_value(true)
+                .require_equals(true)
+                .help("Autogenerate a passphrase (default is 7 words)")
                 .conflicts_with("keyfile"),
         )
         .arg(
@@ -228,8 +232,12 @@ pub fn get_matches() -> clap::ArgMatches {
             .arg(
                 Arg::new("autogenerate")
                     .long("auto")
-                    .takes_value(false)
-                    .help("Autogenerate a passphrase")
+                    .value_name("# of words")
+                    .min_values(0)
+                    .default_missing_value("7")
+                    .takes_value(true)
+                    .require_equals(true)
+                    .help("Autogenerate a passphrase (default is 7 words)")
                     .conflicts_with("keyfile"),
             )
             .arg(
@@ -364,9 +372,13 @@ pub fn get_matches() -> clap::ArgMatches {
                         .arg(
                             Arg::new("autogenerate")
                                 .long("auto")
-                                .takes_value(false)
-                                .help("Autogenerate a passphrase (this will be your new key)")
-                                .conflicts_with("keyfile-new"),
+                                .value_name("# of words")
+                                .min_values(0)
+                                .default_missing_value("7")
+                                .takes_value(true)
+                                .require_equals(true)
+                                .help("Autogenerate a passphrase (default is 7 words)")
+                                .conflicts_with("keyfile"),
                         )
                         .arg(
                             Arg::new("argon")
@@ -411,9 +423,13 @@ pub fn get_matches() -> clap::ArgMatches {
                         .arg(
                             Arg::new("autogenerate")
                                 .long("auto")
-                                .takes_value(false)
-                                .help("Autogenerate a passphrase (this will be your new key)")
-                                .conflicts_with("keyfile-new"),
+                                .value_name("# of words")
+                                .min_values(0)
+                                .default_missing_value("7")
+                                .takes_value(true)
+                                .require_equals(true)
+                                .help("Autogenerate a passphrase (default is 7 words)")
+                                .conflicts_with("keyfile"),
                         )
                         .arg(
                             Arg::new("keyfile-old")

--- a/dexios/src/global/parameters.rs
+++ b/dexios/src/global/parameters.rs
@@ -53,7 +53,6 @@ pub fn parameter_handler(sub_matches: &ArgMatches) -> Result<CryptoParams> {
 
         if let Ok(value) = result {
             EraseMode::EraseFile(value)
-
         } else {
             warn!("No amount of passes provided - using the default.");
             EraseMode::EraseFile(1)

--- a/dexios/src/global/parameters.rs
+++ b/dexios/src/global/parameters.rs
@@ -51,13 +51,13 @@ pub fn parameter_handler(sub_matches: &ArgMatches) -> Result<CryptoParams> {
             .context("No amount of passes specified")?
             .parse();
 
-        let passes = if let Ok(value) = result {
-            value
+        if let Ok(value) = result {
+            EraseMode::EraseFile(value)
+
         } else {
-            warn!("Unable to read number of passes provided - using the default.");
-            2
-        };
-        EraseMode::EraseFile(passes)
+            warn!("No amount of passes provided - using the default.");
+            EraseMode::EraseFile(1)
+        }
     } else {
         EraseMode::IgnoreFile
     };

--- a/dexios/src/global/states.rs
+++ b/dexios/src/global/states.rs
@@ -142,7 +142,10 @@ impl Key {
             sub_matches.try_contains_id("autogenerate"),
             params.autogenerate,
         ) {
-            let result = sub_matches.value_of("autogenerate").context("No amount of words specified")?.parse::<i32>();
+            let result = sub_matches
+                .value_of("autogenerate")
+                .context("No amount of words specified")?
+                .parse::<i32>();
             if let Ok(value) = result {
                 Key::Generate(value)
             } else {


### PR DESCRIPTION
This implements some changes mentioned in the [PrivacyGuides discussion](https://github.com/privacyguides/privacyguides.org/discussions/1352#discussioncomment-3675030) for Dexios.

New passphrases will now be in the format of: `word-word-word-word-word-word-word` (with the amount of words being customizable). This can be done with `dexios encrypt --auto=n`, where `n` is the amount of words.