### PR TITLE
Adding locked

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ section of the Documentation.
 
 You can install Dexios through cargo, with:
 
-`cargo install dexios`
+```
+cargo install dexios --locked
+```
 
 Or you can download a pre-compiled binary from
 [the releases page](https://github.com/brxken128/dexios/releases)!


### PR DESCRIPTION
When some time has passed since the release of a program, new dependencies can prevent cargo from building that application. The `--locked` flag forces cargo to build the application with the original dependencies in which it was released. Changing to a block of code allows you to copy it with the button on the right.